### PR TITLE
[IMP] Automatic handling of commissions

### DIFF
--- a/sale_commission/__openerp__.py
+++ b/sale_commission/__openerp__.py
@@ -45,6 +45,7 @@
         "Giorgio Borelli <giorgio.borelli@abstract.it>",
         "Daniel Campos <danielcampos@avanzosc.es>",
         "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
+        "Vincent Vinet <vincent.vinet@savoirfairelinux.com>",
     ],
     "data": [
         "security/ir.model.access.csv",
@@ -56,7 +57,6 @@
         "views/settlement_view.xml",
         "wizard/wizard_settle.xml",
         "wizard/wizard_invoice.xml",
-        # "report/cc_commission_report.xml"
     ],
     "demo": [
         # 'demo/sale_agent_demo.xml',

--- a/sale_commission/models/__init__.py
+++ b/sale_commission/models/__init__.py
@@ -19,9 +19,9 @@
 #
 ##############################################################################
 
+from . import account_invoice
 from . import product_template
 from . import sale_commission
 from . import res_partner
 from . import sale_order
-from . import account_invoice
 from . import settlement

--- a/sale_commission/models/account_invoice.py
+++ b/sale_commission/models/account_invoice.py
@@ -128,13 +128,13 @@ class AccountInvoiceLineAgent(models.Model):
     @api.depends('commission.commission_type', 'invoice_line.price_subtotal')
     def _get_amount(self):
         self.amount = 0.0
-        if (not self.invoice_line.product_id.commission_free and
-                self.commission):
-            subtotal = self.invoice_line.price_subtotal
-            if self.commission.commission_type == 'fixed':
-                self.amount = subtotal * (self.commission.fix_qty / 100.0)
-            else:
-                self.amount = self.commission.calculate_section(subtotal)
+        sign = {
+            'out_invoice': 1, 'in_invoice': -1,
+            'out_refund': -1, 'in_refund': 1,
+        }[self.invoice.type or 'out_invoice']
+        amount = self.commission.compute_invoice_commission(
+            self.invoice_line)
+        self.amount = sign * amount
 
     @api.one
     @api.depends('agent_line', 'agent_line.settlement.state', 'invoice',

--- a/sale_commission/models/account_invoice.py
+++ b/sale_commission/models/account_invoice.py
@@ -70,24 +70,19 @@ class AccountInvoice(models.Model):
 
 
 class AccountInvoiceLine(models.Model):
+    """Invoice Line inherit to add commissions"""
     _inherit = "account.invoice.line"
 
     @api.model
-    def _default_agents(self):
-        agents = []
-        if self.env.context.get('partner_id'):
-            partner = self.env['res.partner'].browse(
-                self.env.context['partner_id'])
-            for agent in partner.agents:
-                agents.append({'agent': agent.id,
-                               'commission': agent.commission.id})
-        return [(0, 0, x) for x in agents]
+    def _default_commissions(self):
+        res = self.env['sale.commission'].get_default_commissions()
+        return [(0, 0, x) for x in res]
 
     agents = fields.One2many(
         comodel_name="account.invoice.line.agent",
         inverse_name="invoice_line", string="Agents & commissions",
         help="Agents/Commissions related to the invoice line.",
-        default=_default_agents, copy=True)
+        default=_default_commissions, copy=False)
     commission_free = fields.Boolean(
         string="Comm. free", related="product_id.commission_free",
         store=True, readonly=True)

--- a/sale_commission/models/res_partner.py
+++ b/sale_commission/models/res_partner.py
@@ -22,6 +22,13 @@
 ##############################################################################
 from openerp import models, fields, api
 
+from .sale_commission import (
+    PERIOD_MONTH,
+    PERIOD_QUARTER,
+    PERIOD_SEMI,
+    PERIOD_YEAR,
+)
+
 
 class ResPartner(models.Model):
     """Add some fields related to commissions"""
@@ -44,10 +51,10 @@ class ResPartner(models.Model):
              "agent is assigned. It can be changed on each operation if "
              "needed.")
     settlement = fields.Selection(
-        selection=[("monthly", "Monthly"),
-                   ("quaterly", "Quarterly"),
-                   ("semi", "Semi-annual"),
-                   ("annual", "Annual")],
+        selection=[(PERIOD_MONTH, "Monthly"),
+                   (PERIOD_QUARTER, "Quarterly"),
+                   (PERIOD_SEMI, "Semi-annual"),
+                   (PERIOD_YEAR, "Annual")],
         string="Settlement period", default="monthly", required=True)
     settlements = fields.One2many(
         comodel_name="sale.commission.settlement", inverse_name="agent",

--- a/sale_commission/models/sale_commission.py
+++ b/sale_commission/models/sale_commission.py
@@ -115,6 +115,32 @@ class SaleCommission(models.Model):
                 return base * section.percent / 100.0
         return 0.0
 
+    def get_default_commissions(self):
+        partner_obj = self.env['res.partner']
+        res = []
+        if self.env.context.get('partner_id'):
+            partner = partner_obj.browse(
+                self.env.context['partner_id'])
+            for agent in partner.agents:
+                if agent.commission and agent.commission.has_own_scope:
+                    comm = agent.commission
+                    res.append({
+                        'agent': agent.id,
+                        'commission': comm.id,
+                    })
+
+            for agent in partner_obj.search(
+                    [('company_id', '=', partner.company_id.id),
+                     ('agent', '=', True)]):
+                if agent.commission and agent.commission.has_company_scope:
+                    comm = agent.commission
+                    res.append({
+                        'agent': agent.id,
+                        'commission': comm.id,
+                    })
+
+        return res
+
 
 class SaleCommissionSection(models.Model):
     _name = "sale.commission.section"

--- a/sale_commission/models/sale_commission.py
+++ b/sale_commission/models/sale_commission.py
@@ -23,6 +23,12 @@
 from openerp import models, fields, api, exceptions, _
 
 
+PERIOD_MONTH = "monthly"
+PERIOD_QUARTER = "quaterly"
+PERIOD_SEMI = "semi"
+PERIOD_YEAR = "annual"
+
+
 class SaleCommission(models.Model):
     _name = "sale.commission"
     _description = "Commission in sales"
@@ -36,6 +42,70 @@ class SaleCommission(models.Model):
     sections = fields.One2many(
         comodel_name="sale.commission.section", inverse_name="commission")
     active = fields.Boolean(default=True)
+    period = fields.Selection(
+        selection=[(PERIOD_MONTH, "Monthly"),
+                   (PERIOD_QUARTER, "Every quarter"),
+                   (PERIOD_SEMI, "Every semester"),
+                   (PERIOD_YEAR, "Every year")],
+        required=True, default=PERIOD_MONTH,
+    )
+    scope = fields.Selection(
+        selection=[("own_sales", "On his customer sales"),
+                   ("company_sales", "On company sales"),
+                   ("own_margin", "On his customers margin"),
+                   ("company_margin", "On company margin")],
+        required=True, default="own_sales",
+    )
+
+    has_company_scope = fields.Boolean(compute="_compute_scope")
+    has_own_scope = fields.Boolean(compute="_compute_scope")
+
+    @api.one
+    def _compute_scope(self):
+        self.has_company_scope = self.scope in ("company_sales",
+                                                "company_margin")
+        self.has_own_scope = self.scope in ("own_sales", "own_margin")
+
+    @api.multi
+    def compute_sale_commission(self, sale_line):
+        """ Compute the commission on a sale order line """
+        if self.scope in ("own_sales", "company_sales"):
+            base = sale_line.price_subtotal
+        elif self.scope in ("own_margin", "company_margin"):
+            # Compute margin: subtotal - unit cost * qty
+            base = sale_line.price_subtotal - (
+                sale_line.product_id.standard_price * sale_line.product_uom_qty
+            )
+        return self.compute_commission(
+            sale_line.product_id,
+            base,
+        )
+
+    @api.multi
+    def compute_invoice_commission(self, invoice_line):
+        """ Compute the commission on a invoice line """
+        if self.scope in ("own_sales", "company_sales"):
+            base = invoice_line.price_subtotal
+        elif self.scope in ("own_margin", "company_margin"):
+            # Compute margin: subtotal - unit cost * qty
+            base = invoice_line.price_subtotal - (
+                invoice_line.product_id.standard_price * invoice_line.quantity
+            )
+        return self.compute_commission(
+            invoice_line.product_id,
+            base,
+        )
+
+    @api.multi
+    def compute_commission(self, product_id, price_subtotal):
+        self.ensure_one()
+        if product_id.commission_free:
+            return 0.0
+
+        if self.commission_type == 'fixed':
+            return price_subtotal * (self.fix_qty / 100.0)
+        elif self.commission_type == 'section':
+            return self.calculate_section(price_subtotal)
 
     @api.multi
     def calculate_section(self, base):

--- a/sale_commission/models/sale_order.py
+++ b/sale_commission/models/sale_order.py
@@ -42,20 +42,14 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     @api.model
-    def _default_agents(self):
-        agents = []
-        if self.env.context.get('partner_id'):
-            partner = self.env['res.partner'].browse(
-                self.env.context['partner_id'])
-            for agent in partner.agents:
-                agents.append({'agent': agent.id,
-                               'commission': agent.commission.id})
-        return [(0, 0, x) for x in agents]
+    def _default_commissions(self):
+        res = self.env['sale.commission'].get_default_commissions()
+        return [(0, 0, x) for x in res]
 
     agents = fields.One2many(
         string="Agents & commissions",
         comodel_name='sale.order.line.agent', inverse_name='sale_line',
-        copy=True, readonly=True, default=_default_agents)
+        copy=True, default=_default_commissions)
     commission_free = fields.Boolean(
         string="Comm. free", related="product_id.commission_free",
         store=True, readonly=True)

--- a/sale_commission/models/sale_order.py
+++ b/sale_commission/models/sale_order.py
@@ -97,10 +97,6 @@ class SaleOrderLineAgent(models.Model):
     @api.depends('commission.commission_type', 'sale_line.price_subtotal')
     def _get_amount(self):
         self.amount = 0.0
-        if (not self.sale_line.product_id.commission_free and
-                self.commission):
-            subtotal = self.sale_line.price_subtotal
-            if self.commission.commission_type == 'fixed':
-                self.amount = subtotal * (self.commission.fix_qty / 100.0)
-            else:
-                self.amount = self.commission.calculate_section(subtotal)
+        if self.commission:
+            self.amount = self.commission.compute_sale_commission(
+                self.sale_line)

--- a/sale_commission/tests/__init__.py
+++ b/sale_commission/tests/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import test_periods

--- a/sale_commission/tests/test_periods.py
+++ b/sale_commission/tests/test_periods.py
@@ -1,0 +1,80 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from datetime import date
+
+from openerp.tests import TransactionCase
+
+from ..models.sale_commission import (
+    PERIOD_YEAR,
+    PERIOD_SEMI,
+    PERIOD_QUARTER,
+)
+
+
+class TestPeriodRanges(TransactionCase):
+    """
+    Test period ranges for settlement wizard
+    """
+
+    def setUp(self):
+        super(TestPeriodRanges, self).setUp()
+        self.w = self.env["sale.commission.make.settle"]
+
+    def test_year(self):
+        self.assertEquals(
+            self.w._get_period_start(PERIOD_YEAR, date(2015, 6, 1)),
+            date(2015, 1, 1), "Yearly period start on Jan 1st")
+
+        self.assertEquals(
+            self.w._get_period_end(PERIOD_YEAR, date(2015, 6, 1)),
+            date(2015, 12, 31), "Yearly period ends dec 31st")
+
+    def test_semi(self):
+        self.assertEquals(
+            self.w._get_period_start(PERIOD_SEMI, date(2015, 5, 5)),
+            date(2015, 1, 1), "First semester: Jan-June")
+        self.assertEquals(
+            self.w._get_period_end(PERIOD_SEMI, date(2015, 5, 5)),
+            date(2015, 6, 30), "First semester: Jan-June")
+
+        self.assertEquals(
+            self.w._get_period_start(PERIOD_SEMI, date(2015, 7, 5)),
+            date(2015, 7, 1), "First semester: July-Dec")
+        self.assertEquals(
+            self.w._get_period_end(PERIOD_SEMI, date(2015, 7, 5)),
+            date(2015, 12, 31), "First semester: July-Dec")
+
+    def test_quarter(self):
+        for d, s, e, msg in [
+            (date(2015, 1, 1), date(2015, 1, 1), date(2015, 3, 31),
+             "Q1: Jan-Mar"),
+            (date(2015, 6, 30), date(2015, 4, 1), date(2015, 6, 30),
+             "Q2: Apr-Jun"),
+            (date(2015, 8, 5), date(2015, 7, 1), date(2015, 9, 30),
+             "Q3: Jul-Sep"),
+            (date(2015, 10, 31), date(2015, 10, 1), date(2015, 12, 31),
+             "Q3: Oct-Dec")]:
+            self.assertEquals(self.w._get_period_start(PERIOD_QUARTER, d),
+                              s, msg)
+            self.assertEquals(self.w._get_period_end(PERIOD_QUARTER, d),
+                              e, msg)

--- a/sale_commission/views/account_invoice_view.xml
+++ b/sale_commission/views/account_invoice_view.xml
@@ -36,8 +36,7 @@
                 </field>
                 <xpath expr="//field[@name='invoice_line']/tree//field[@name='price_subtotal']" position="after">
                     <field name="commission_free"/>
-                    <field name="agents"
-                           attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                    <field name="agents" invisible="1" />
                 </xpath>
                 <field name="amount_total" position="after">
                     <field name="commission_total"

--- a/sale_commission/views/sale_commission_view.xml
+++ b/sale_commission/views/sale_commission_view.xml
@@ -25,6 +25,8 @@
                         </group>
                         <group>
                             <field name="commission_type" />
+                            <field name="period" />
+                            <field name="scope" />
                         </group>
                     </group>
                     <group string="Rates definition" colspan="4">

--- a/sale_commission/views/sale_order_view.xml
+++ b/sale_commission/views/sale_order_view.xml
@@ -12,13 +12,11 @@
                 </field>
                 <xpath expr="//field[@name='order_line']/tree//field[@name='price_subtotal']" position="after">
                     <field name="commission_free"/>
-                    <field name="agents"
-                           attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                    <field name="agents" invisible="1" />
                 </xpath>
                 <xpath expr="//field[@name='order_line']/form//field[@name='address_allotment_id']" position="after">
                     <field name="commission_free"/>
-                    <field name="agents"
-                           attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                    <field name="agents" invisible="1" />
                 </xpath>
                 <field name="amount_total" position="after">
                     <field name="commission_total"

--- a/sale_commission/wizard/wizard_settle.py
+++ b/sale_commission/wizard/wizard_settle.py
@@ -24,6 +24,13 @@ from openerp import models, fields, api, exceptions, _
 from datetime import date, timedelta
 from dateutil.relativedelta import relativedelta
 
+from ..models.sale_commission import (
+    PERIOD_MONTH,
+    PERIOD_QUARTER,
+    PERIOD_SEMI,
+    PERIOD_YEAR,
+)
+
 
 class SaleCommissionMakeSettle(models.TransientModel):
     _name = "sale.commission.make.settle"
@@ -32,35 +39,43 @@ class SaleCommissionMakeSettle(models.TransientModel):
     agents = fields.Many2many(comodel_name='res.partner',
                               domain="[('agent', '=', True)]")
 
-    def _get_period_start(self, agent, date_to):
+    @classmethod
+    def _get_period_start(cls, period, date_to):
         if isinstance(date_to, basestring):
             date_to = fields.Date.from_string(date_to)
-        if agent.settlement == 'monthly':
+        if period == PERIOD_MONTH:
             return date(month=date_to.month, year=date_to.year, day=1)
-        elif agent.settlement == 'quaterly':
+        elif period == PERIOD_QUARTER:
             # Get first month of the date quarter
-            month = ((date_to.month - 1) // 3 + 1) * 3
+            month = ((date_to.month - 1) // 3) * 3 + 1
             return date(month=month, year=date_to.year, day=1)
-        elif agent.settlement == 'semi':
+        elif period == PERIOD_SEMI:
             if date_to.month > 6:
                 return date(month=7, year=date_to.year, day=1)
             else:
                 return date(month=1, year=date_to.year, day=1)
-        elif agent.settlement == 'annual':
+        elif period == PERIOD_YEAR:
             return date(month=1, year=date_to.year, day=1)
         else:
             raise exceptions.Warning(_("Settlement period not valid."))
 
-    def _get_next_period_date(self, agent, current_date):
+    @classmethod
+    def _get_period_end(cls, period, date):
+        start = cls._get_period_start(period, date)
+        end = cls._get_next_period_date(period, start) - relativedelta(days=1)
+        return end
+
+    @classmethod
+    def _get_next_period_date(cls, period, current_date):
         if isinstance(current_date, basestring):
             current_date = fields.Date.from_string(current_date)
-        if agent.settlement == 'monthly':
+        if period == PERIOD_MONTH:
             return current_date + relativedelta(months=1)
-        elif agent.settlement == 'quaterly':
+        elif period == PERIOD_QUARTER:
             return current_date + relativedelta(months=3)
-        elif agent.settlement == 'semi':
+        elif period == PERIOD_SEMI:
             return current_date + relativedelta(months=6)
-        elif agent.settlement == 'annual':
+        elif period == PERIOD_YEAR:
             return current_date + relativedelta(years=1)
         else:
             raise exceptions.Warning(_("Settlement period not valid."))
@@ -76,30 +91,47 @@ class SaleCommissionMakeSettle(models.TransientModel):
                 [('agent', '=', True)])
         date_to = fields.Date.from_string(self.date_to)
         for agent in self.agents:
-            date_to_agent = self._get_period_start(agent, date_to)
+            agent_period = agent.settlement
+            date_to_agent = self._get_period_start(agent_period, date_to)
             # Get non settled invoices
-            agent_lines = agent_line_obj.search(
+            commission_lines = agent_line_obj.search(
                 [('invoice_date', '<', date_to_agent),
                  ('agent', '=', agent.id),
                  ('settled', '=', False)], order='invoice_date')
-            if agent_lines:
-                pos = 0
-                sett_to = fields.Date.to_string(date(year=1900, month=1,
-                                                     day=1))
-                while pos < len(agent_lines):
-                    if agent_lines[pos].invoice_date > sett_to:
-                        sett_from = self._get_period_start(
-                            agent, agent_lines[pos].invoice_date)
-                        sett_to = fields.Date.to_string(
-                            self._get_next_period_date(agent, sett_from) -
+
+            if not commission_lines:
+                # Nothing to settle, carry on
+                continue
+            # Group lines according to period types
+            periods = {}
+            for line in commission_lines:
+                periods.setdefault(line.commission.period, []).append(line)
+
+            # Go through each period type, creating settlements as required
+            for period, lines in periods.items():
+                sett_to = date(year=1900, month=1, day=1)
+                sett_to_str = fields.Date.to_string(sett_to)
+                for line in lines:
+                    if line.invoice_date > sett_to_str:
+                        sett_from = self._get_period_start(period,
+                                                           line.invoice_date)
+                        sett_to = (
+                            self._get_next_period_date(period, sett_from) -
                             timedelta(days=1))
+                        sett_to_str = fields.Date.to_string(sett_to)
+
+                        # Do not allow settling unfinished periods
+                        if sett_to >= date_to:
+                            break
+
                         sett_from = fields.Date.to_string(sett_from)
                         settlement = settlement_obj.create(
                             {'agent': agent.id,
                              'date_from': sett_from,
-                             'date_to': sett_to})
+                             'date_to': sett_to_str})
+
                     settlement_line_obj.create(
                         {'settlement': settlement.id,
-                         'agent_line': [(6, 0, [agent_lines[pos].id])]})
-                    pos += 1
+                         'agent_line': [(6, 0, [line.id])]})
+
         return True


### PR DESCRIPTION
Hide commissions from view in sales order and invoices. This lets the default
commissions do their work. The interface really breaks down when there are
many commissions to set, and normally there shouldn't be a need for manual
input on a per-line basis.

This is rebased on #28
This is part 3 of #27 
