### PR TITLE
[IMP] Handle multiple commissions

### DIFF
--- a/hr_commission/views/res_partner_view.xml
+++ b/hr_commission/views/res_partner_view.xml
@@ -7,7 +7,7 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="sale_commission.view_partner_form_agent" />
             <field name="arch" type="xml">
-                <field name="commission" position="after">
+                <field name="agent_type" position="after">
                     <field name="employee"
                            attrs="{'invisible': [('agent_type', '!=', 'salesman')]}" />
                 </field>

--- a/sale_commission/__openerp__.py
+++ b/sale_commission/__openerp__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 {
     'name': 'Sales commissions',
-    'version': '2.0',
+    'version': '2.1',
     'author': 'Pexego, '
               'Savoire-faire linux, '
               'Avanzosc, '

--- a/sale_commission/__openerp__.py
+++ b/sale_commission/__openerp__.py
@@ -45,6 +45,7 @@
         "Giorgio Borelli <giorgio.borelli@abstract.it>",
         "Daniel Campos <danielcampos@avanzosc.es>",
         "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
+        "Vincent Vinet <vincent.vinet@savoirfairelinux.com>",
     ],
     "data": [
         "security/ir.model.access.csv",
@@ -56,7 +57,6 @@
         "views/settlement_view.xml",
         "wizard/wizard_settle.xml",
         "wizard/wizard_invoice.xml",
-        # "report/cc_commission_report.xml"
     ],
     "demo": [
         # 'demo/sale_agent_demo.xml',

--- a/sale_commission/__openerp__.py
+++ b/sale_commission/__openerp__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 {
     'name': 'Sales commissions',
-    'version': '2.1',
+    'version': '8.0.2.1.0',
     'author': 'Pexego, '
               'Savoire-faire linux, '
               'Avanzosc, '

--- a/sale_commission/migrations/8.0.2.1.0/post-update.py
+++ b/sale_commission/migrations/8.0.2.1.0/post-update.py
@@ -1,0 +1,34 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+def restore_relation_data(cr):
+    cr.execute(
+        """
+        INSERT INTO agent_commission_rel (partner_id, commission_id)
+        SELECT agent_id, commission_id FROM tmp_mig_agent_commissions
+        """)
+    cr.execute("""DROP TABLE tmp_mig_agent_commissions""")
+
+
+def migrate(cr, installed_version):
+    restore_relation_data(cr)

--- a/sale_commission/migrations/8.0.2.1.0/post-update.py
+++ b/sale_commission/migrations/8.0.2.1.0/post-update.py
@@ -28,6 +28,14 @@ def restore_relation_data(cr):
         SELECT agent_id, commission_id FROM tmp_mig_agent_commissions
         """)
     cr.execute("""DROP TABLE tmp_mig_agent_commissions""")
+    cr.execute(
+        """
+        INSERT INTO settlement_commission_line_rel
+        (commission_line_id, settlement_id)
+        SELECT agent_line_id, settlmeent_id
+        FROM tmp_mig_settlement_line_rel
+        """)
+    cr.execute("""DROP TABLE tmp_mig_settlement_line_rel""")
 
 
 def migrate(cr, installed_version):

--- a/sale_commission/migrations/8.0.2.1.0/pre-update.py
+++ b/sale_commission/migrations/8.0.2.1.0/pre-update.py
@@ -36,7 +36,6 @@ CONSTRAINT_DROPS = [
 ]
 
 
-
 def rename_tables(cr):
     for src, dst in TABLE_RENAMES:
         cr.execute("ALTER TABLE {src} RENAME TO {dst}".format(
@@ -84,6 +83,7 @@ def drop_constraints(cr):
                 """.format(table=table,
                            name=name))
 
+
 def update_model_data(cr):
     cr.executemany(
         """
@@ -92,12 +92,12 @@ def update_model_data(cr):
         WHERE name = %(oldname)s
         """,
         [{"oldname": "invoice_line_agent_tree",
-          "name":"invoice_line_commission_tree"},
+          "name": "invoice_line_commission_tree"},
          {"oldname": "invoice_line_form_agent",
           "name": "invoice_line_form_commission"},
          {"oldname": "invoice_form_agent",
           "name": "invoice_form_commission"},
-        ])
+         ])
 
 
 def migrate(cr, installed_version):

--- a/sale_commission/migrations/8.0.2.1.0/pre-update.py
+++ b/sale_commission/migrations/8.0.2.1.0/pre-update.py
@@ -1,0 +1,79 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+TABLE_RENAMES = [
+    ("account_invoice_line_agent", "account_invoice_line_commission"),
+    ("sale_order_line_agent", "sale_order_line_commission"),
+    ("settlement_agent_line_rel", "settlement_commission_line_rel"),
+]
+
+COL_RENAMES = [
+    ("settlement_commission_line_rel", [
+        ("agent_line_id", "commission_line_id"),
+    ]),
+]
+
+CONSTRAINT_DROPS = [
+    "account_invoice_line_agent_unique_agent",
+    "sale_order_line_agent_unique_agent",
+]
+
+
+def rename_tables(cr):
+    for src, dst in TABLE_RENAMES:
+        cr.execute("ALTER TABLE {src} RENAME TO {dst}".format(
+            src=src, dst=dst))
+
+    for tbl, renames in COL_RENAMES:
+        for src, dst in renames:
+            cr.execute(
+                """
+                ALTER TABLE {tbl}
+                RENAME COLUMN {src} TO {dst}
+                """.format(
+                    tbl=tbl,
+                    src=src,
+                    dst=dst,
+                ))
+
+
+def save_relation_data(cr):
+    cr.execute(
+        """
+        CREATE TABLE tmp_mig_agent_commissions AS
+          SELECT id as agent_id, commission as commission_id
+          FROM res_partner WHERE commission IS NOT NULL
+        """)
+    cr.execute(
+        """ALTER TABLE res_partner DROP COLUMN commission"""
+    )
+
+
+def drop_constraints(cr):
+    for name in CONSTRAINT_DROPS:
+        cr.execute("DROP CONSTRAINT IF EXISTS {0}".format(name))
+
+
+def migrate(cr, installed_version):
+    rename_tables(cr)
+    save_relation_data(cr)
+    drop_constraints(cr)

--- a/sale_commission/models/__init__.py
+++ b/sale_commission/models/__init__.py
@@ -19,9 +19,9 @@
 #
 ##############################################################################
 
+from . import account_invoice
 from . import product_template
 from . import sale_commission
 from . import res_partner
 from . import sale_order
-from . import account_invoice
 from . import settlement

--- a/sale_commission/models/account_invoice.py
+++ b/sale_commission/models/account_invoice.py
@@ -128,13 +128,13 @@ class AccountInvoiceLineAgent(models.Model):
     @api.depends('commission.commission_type', 'invoice_line.price_subtotal')
     def _get_amount(self):
         self.amount = 0.0
-        if (not self.invoice_line.product_id.commission_free and
-                self.commission):
-            subtotal = self.invoice_line.price_subtotal
-            if self.commission.commission_type == 'fixed':
-                self.amount = subtotal * (self.commission.fix_qty / 100.0)
-            else:
-                self.amount = self.commission.calculate_section(subtotal)
+        sign = {
+            'out_invoice': 1, 'in_invoice': -1,
+            'out_refund': -1, 'in_refund': 1,
+        }[self.invoice.type or 'out_invoice']
+        amount = self.commission.compute_invoice_commission(
+            self.invoice_line)
+        self.amount = sign * amount
 
     @api.one
     @api.depends('agent_line', 'agent_line.settlement.state', 'invoice',

--- a/sale_commission/models/account_invoice.py
+++ b/sale_commission/models/account_invoice.py
@@ -70,24 +70,19 @@ class AccountInvoice(models.Model):
 
 
 class AccountInvoiceLine(models.Model):
+    """Invoice Line inherit to add commissions"""
     _inherit = "account.invoice.line"
 
     @api.model
-    def _default_agents(self):
-        agents = []
-        if self.env.context.get('partner_id'):
-            partner = self.env['res.partner'].browse(
-                self.env.context['partner_id'])
-            for agent in partner.agents:
-                agents.append({'agent': agent.id,
-                               'commission': agent.commission.id})
-        return [(0, 0, x) for x in agents]
+    def _default_commissions(self):
+        res = self.env['sale.commission'].get_default_commissions()
+        return [(0, 0, x) for x in res]
 
     agents = fields.One2many(
         comodel_name="account.invoice.line.agent",
         inverse_name="invoice_line", string="Agents & commissions",
         help="Agents/Commissions related to the invoice line.",
-        default=_default_agents, copy=True)
+        default=_default_commissions, copy=False)
     commission_free = fields.Boolean(
         string="Comm. free", related="product_id.commission_free",
         store=True, readonly=True)

--- a/sale_commission/models/account_invoice.py
+++ b/sale_commission/models/account_invoice.py
@@ -157,4 +157,3 @@ class AccountInvoiceLineAgentCommission(models.Model):
         self.settled = (self.invoice.state not in ('open', 'paid') or
                         any(x.settlement.state != 'cancel'
                             for x in self.agent_line))
-

--- a/sale_commission/models/account_invoice.py
+++ b/sale_commission/models/account_invoice.py
@@ -127,11 +127,6 @@ class AccountInvoiceLineAgentCommission(models.Model):
         readonly=True)
     product = fields.Many2one(
         comodel_name='product.product', related="invoice_line.product_id")
-    agent = fields.Many2one(
-        comodel_name="res.partner", required=True, ondelete="restrict",
-        domain="[('agent', '=', True)]")
-    commission = fields.Many2one(
-        comodel_name="sale.commission", required=True, ondelete="restrict")
     amount = fields.Float(
         string="Amount settled", compute="_get_amount", store=True)
     agent_line = fields.Many2many(

--- a/sale_commission/models/res_partner.py
+++ b/sale_commission/models/res_partner.py
@@ -45,8 +45,10 @@ class ResPartner(models.Model):
     agent_type = fields.Selection(
         selection=[("agent", "External agent")], string="Type", required=True,
         default="agent")
-    commission = fields.Many2one(
+    commissions = fields.Many2many(
         string="Commission", comodel_name="sale.commission",
+        relation="agent_commission_rel",
+        column1="partner_id", column2="commission_id",
         help="This is the default commission used in the sales where this "
              "agent is assigned. It can be changed on each operation if "
              "needed.")

--- a/sale_commission/models/res_partner.py
+++ b/sale_commission/models/res_partner.py
@@ -22,6 +22,13 @@
 ##############################################################################
 from openerp import models, fields, api
 
+from .sale_commission import (
+    PERIOD_MONTH,
+    PERIOD_QUARTER,
+    PERIOD_SEMI,
+    PERIOD_YEAR,
+)
+
 
 class ResPartner(models.Model):
     """Add some fields related to commissions"""
@@ -44,10 +51,10 @@ class ResPartner(models.Model):
              "agent is assigned. It can be changed on each operation if "
              "needed.")
     settlement = fields.Selection(
-        selection=[("monthly", "Monthly"),
-                   ("quaterly", "Quarterly"),
-                   ("semi", "Semi-annual"),
-                   ("annual", "Annual")],
+        selection=[(PERIOD_MONTH, "Monthly"),
+                   (PERIOD_QUARTER, "Quarterly"),
+                   (PERIOD_SEMI, "Semi-annual"),
+                   (PERIOD_YEAR, "Annual")],
         string="Settlement period", default="monthly", required=True)
     settlements = fields.One2many(
         comodel_name="sale.commission.settlement", inverse_name="agent",

--- a/sale_commission/models/sale_commission.py
+++ b/sale_commission/models/sale_commission.py
@@ -115,6 +115,32 @@ class SaleCommission(models.Model):
                 return base * section.percent / 100.0
         return 0.0
 
+    def get_default_commissions(self):
+        partner_obj = self.env['res.partner']
+        res = []
+        if self.env.context.get('partner_id'):
+            partner = partner_obj.browse(
+                self.env.context['partner_id'])
+            for agent in partner.agents:
+                if agent.commission and agent.commission.has_own_scope:
+                    comm = agent.commission
+                    res.append({
+                        'agent': agent.id,
+                        'commission': comm.id,
+                    })
+
+            for agent in partner_obj.search(
+                    [('company_id', '=', partner.company_id.id),
+                     ('agent', '=', True)]):
+                if agent.commission and agent.commission.has_company_scope:
+                    comm = agent.commission
+                    res.append({
+                        'agent': agent.id,
+                        'commission': comm.id,
+                    })
+
+        return res
+
 
 class SaleCommissionSection(models.Model):
     _name = "sale.commission.section"

--- a/sale_commission/models/sale_commission.py
+++ b/sale_commission/models/sale_commission.py
@@ -122,22 +122,21 @@ class SaleCommission(models.Model):
             partner = partner_obj.browse(
                 self.env.context['partner_id'])
             for agent in partner.agents:
-                if agent.commission and agent.commission.has_own_scope:
-                    comm = agent.commission
-                    res.append({
-                        'agent': agent.id,
-                        'commission': comm.id,
-                    })
-
+                res.extend(
+                    {'agent': agent.id,
+                     'commission': comm.id}
+                    for comm in agent.commissions
+                    if comm.has_own_scope
+                )
             for agent in partner_obj.search(
                     [('company_id', '=', partner.company_id.id),
                      ('agent', '=', True)]):
-                if agent.commission and agent.commission.has_company_scope:
-                    comm = agent.commission
-                    res.append({
-                        'agent': agent.id,
-                        'commission': comm.id,
-                    })
+                res.extend(
+                    {'agent': agent.id,
+                     'commission': comm.id}
+                    for comm in agent.commissions
+                    if comm.has_company_scope
+                )
 
         return res
 

--- a/sale_commission/models/sale_commission.py
+++ b/sale_commission/models/sale_commission.py
@@ -23,6 +23,12 @@
 from openerp import models, fields, api, exceptions, _
 
 
+PERIOD_MONTH = "monthly"
+PERIOD_QUARTER = "quaterly"
+PERIOD_SEMI = "semi"
+PERIOD_YEAR = "annual"
+
+
 class SaleCommission(models.Model):
     _name = "sale.commission"
     _description = "Commission in sales"
@@ -36,6 +42,70 @@ class SaleCommission(models.Model):
     sections = fields.One2many(
         comodel_name="sale.commission.section", inverse_name="commission")
     active = fields.Boolean(default=True)
+    period = fields.Selection(
+        selection=[(PERIOD_MONTH, "Monthly"),
+                   (PERIOD_QUARTER, "Every quarter"),
+                   (PERIOD_SEMI, "Every semester"),
+                   (PERIOD_YEAR, "Every year")],
+        required=True, default=PERIOD_MONTH,
+    )
+    scope = fields.Selection(
+        selection=[("own_sales", "On his customer sales"),
+                   ("company_sales", "On company sales"),
+                   ("own_margin", "On his customers margin"),
+                   ("company_margin", "On company margin")],
+        required=True, default="own_sales",
+    )
+
+    has_company_scope = fields.Boolean(compute="_compute_scope")
+    has_own_scope = fields.Boolean(compute="_compute_scope")
+
+    @api.one
+    def _compute_scope(self):
+        self.has_company_scope = self.scope in ("company_sales",
+                                                "company_margin")
+        self.has_own_scope = self.scope in ("own_sales", "own_margin")
+
+    @api.multi
+    def compute_sale_commission(self, sale_line):
+        """ Compute the commission on a sale order line """
+        if self.scope in ("own_sales", "company_sales"):
+            base = sale_line.price_subtotal
+        elif self.scope in ("own_margin", "company_margin"):
+            # Compute margin: subtotal - unit cost * qty
+            base = sale_line.price_subtotal - (
+                sale_line.product_id.standard_price * sale_line.product_uom_qty
+            )
+        return self.compute_commission(
+            sale_line.product_id,
+            base,
+        )
+
+    @api.multi
+    def compute_invoice_commission(self, invoice_line):
+        """ Compute the commission on a invoice line """
+        if self.scope in ("own_sales", "company_sales"):
+            base = invoice_line.price_subtotal
+        elif self.scope in ("own_margin", "company_margin"):
+            # Compute margin: subtotal - unit cost * qty
+            base = invoice_line.price_subtotal - (
+                invoice_line.product_id.standard_price * invoice_line.quantity
+            )
+        return self.compute_commission(
+            invoice_line.product_id,
+            base,
+        )
+
+    @api.multi
+    def compute_commission(self, product_id, price_subtotal):
+        self.ensure_one()
+        if product_id.commission_free:
+            return 0.0
+
+        if self.commission_type == 'fixed':
+            return price_subtotal * (self.fix_qty / 100.0)
+        elif self.commission_type == 'section':
+            return self.calculate_section(price_subtotal)
 
     @api.multi
     def calculate_section(self, base):

--- a/sale_commission/models/sale_order.py
+++ b/sale_commission/models/sale_order.py
@@ -42,20 +42,14 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     @api.model
-    def _default_agents(self):
-        agents = []
-        if self.env.context.get('partner_id'):
-            partner = self.env['res.partner'].browse(
-                self.env.context['partner_id'])
-            for agent in partner.agents:
-                agents.append({'agent': agent.id,
-                               'commission': agent.commission.id})
-        return [(0, 0, x) for x in agents]
+    def _default_commissions(self):
+        res = self.env['sale.commission'].get_default_commissions()
+        return [(0, 0, x) for x in res]
 
     agents = fields.One2many(
         string="Agents & commissions",
         comodel_name='sale.order.line.agent', inverse_name='sale_line',
-        copy=True, readonly=True, default=_default_agents)
+        copy=True, default=_default_commissions)
     commission_free = fields.Boolean(
         string="Comm. free", related="product_id.commission_free",
         store=True, readonly=True)

--- a/sale_commission/models/sale_order.py
+++ b/sale_commission/models/sale_order.py
@@ -27,11 +27,11 @@ class SaleOrder(models.Model):
     _inherit = "sale.order"
 
     @api.one
-    @api.depends('order_line.agents.amount')
+    @api.depends('order_line.commissions.amount')
     def _get_commission_total(self):
         self.commission_total = 0.0
         for line in self.order_line:
-            self.commission_total += sum(x.amount for x in line.agents)
+            self.commission_total += sum(x.amount for x in line.commissions)
 
     commission_total = fields.Float(
         string="Commissions", compute="_get_commission_total",
@@ -46,9 +46,9 @@ class SaleOrderLine(models.Model):
         res = self.env['sale.commission'].get_default_commissions()
         return [(0, 0, x) for x in res]
 
-    agents = fields.One2many(
+    commissions = fields.One2many(
         string="Agents & commissions",
-        comodel_name='sale.order.line.agent', inverse_name='sale_line',
+        comodel_name='sale.order.line.commission', inverse_name='sale_line',
         copy=True, default=_default_commissions)
     commission_free = fields.Boolean(
         string="Comm. free", related="product_id.commission_free",
@@ -58,14 +58,15 @@ class SaleOrderLine(models.Model):
     def _prepare_order_line_invoice_line(self, line, account_id=False):
         vals = super(SaleOrderLine, self)._prepare_order_line_invoice_line(
             line, account_id=account_id)
-        vals['agents'] = [
-            (0, 0, {'agent': x.agent.id,
-                    'commission': x.commission.id}) for x in line.agents]
+        vals['commissions'] = [
+            (0, 0, {'agent': c.agent.id,
+                    'commission': c.commission.id})
+            for c in line.commissions]
         return vals
 
 
-class SaleOrderLineAgent(models.Model):
-    _name = "sale.order.line.agent"
+class SaleOrderLineCommission(models.Model):
+    _name = "sale.order.line.commission"
     _rec_name = "agent"
 
     sale_line = fields.Many2one(
@@ -78,14 +79,9 @@ class SaleOrderLineAgent(models.Model):
     amount = fields.Float(compute="_get_amount", store=True)
 
     _sql_constraints = [
-        ('unique_agent', 'UNIQUE(sale_line, agent)',
-         'You can only add one time each agent.')
+        ('unique_agent', 'UNIQUE(sale_line, agent, commission)',
+         'You can only add one of each commission for each agent.')
     ]
-
-    @api.one
-    @api.onchange('agent')
-    def onchange_agent(self):
-        self.commission = self.agent.commission
 
     @api.one
     @api.depends('commission.commission_type', 'sale_line.price_subtotal')

--- a/sale_commission/models/sale_order.py
+++ b/sale_commission/models/sale_order.py
@@ -79,7 +79,7 @@ class SaleOrderLineCommission(models.Model):
     amount = fields.Float(compute="_get_amount", store=True)
 
     _sql_constraints = [
-        ('unique_agent', 'UNIQUE(sale_line, agent, commission)',
+        ('unique_agent_commission', 'UNIQUE(sale_line, agent, commission)',
          'You can only add one of each commission for each agent.')
     ]
 

--- a/sale_commission/models/sale_order.py
+++ b/sale_commission/models/sale_order.py
@@ -97,10 +97,6 @@ class SaleOrderLineAgent(models.Model):
     @api.depends('commission.commission_type', 'sale_line.price_subtotal')
     def _get_amount(self):
         self.amount = 0.0
-        if (not self.sale_line.product_id.commission_free and
-                self.commission):
-            subtotal = self.sale_line.price_subtotal
-            if self.commission.commission_type == 'fixed':
-                self.amount = subtotal * (self.commission.fix_qty / 100.0)
-            else:
-                self.amount = self.commission.calculate_section(subtotal)
+        if self.commission:
+            self.amount = self.commission.compute_sale_commission(
+                self.sale_line)

--- a/sale_commission/models/settlement.py
+++ b/sale_commission/models/settlement.py
@@ -170,8 +170,8 @@ class SettlementLine(models.Model):
         comodel_name='account.invoice', store=True, string="Invoice",
         related='invoice_line.invoice_id')
     agent = fields.Many2one(
-        comodel_name="res.partner", readonly=True, related="commission_line.agent",
-        store=True)
+        comodel_name="res.partner", related="commission_line.agent",
+        readonly=True, store=True)
     settled_amount = fields.Float(
         related="commission_line.amount", readonly=True, store=True)
     commission = fields.Many2one(

--- a/sale_commission/models/settlement.py
+++ b/sale_commission/models/settlement.py
@@ -158,21 +158,21 @@ class SettlementLine(models.Model):
     settlement = fields.Many2one(
         "sale.commission.settlement", readonly=True, ondelete="cascade",
         required=True)
-    agent_line = fields.Many2many(
-        comodel_name='account.invoice.line.agent',
-        relation='settlement_agent_line_rel', column1='settlement_id',
-        column2='agent_line_id', required=True)
-    date = fields.Date(related="agent_line.invoice_date", store=True)
+    commission_line = fields.Many2many(
+        comodel_name='account.invoice.line.commission',
+        relation='settlement_commission_line_rel', column1='settlement_id',
+        column2='commission_line_id', required=True)
+    date = fields.Date(related="commission_line.invoice_date", store=True)
     invoice_line = fields.Many2one(
         comodel_name='account.invoice.line', store=True,
-        related='agent_line.invoice_line')
+        related='commission_line.invoice_line')
     invoice = fields.Many2one(
         comodel_name='account.invoice', store=True, string="Invoice",
         related='invoice_line.invoice_id')
     agent = fields.Many2one(
-        comodel_name="res.partner", readonly=True, related="agent_line.agent",
+        comodel_name="res.partner", readonly=True, related="commission_line.agent",
         store=True)
     settled_amount = fields.Float(
-        related="agent_line.amount", readonly=True, store=True)
+        related="commission_line.amount", readonly=True, store=True)
     commission = fields.Many2one(
-        comodel_name="sale.commission", related="agent_line.commission")
+        comodel_name="sale.commission", related="commission_line.commission")

--- a/sale_commission/security/ir.model.access.csv
+++ b/sale_commission/security/ir.model.access.csv
@@ -3,8 +3,8 @@
 "access_sale_commission_user","access_sale_commission_user","model_sale_commission","base.group_sale_salesman",1,0,0,0
 "access_sale_commission_section_manager","access_sale_commission_section_manager","model_sale_commission_section","base.group_sale_manager",1,1,1,1
 "access_sale_commission_section_user","access_sale_commission_section_user","model_sale_commission_section","base.group_sale_salesman",1,0,0,0
-"access_sale_order_line_agent","access_sale_order_line_agent","model_sale_order_line_agent","base.group_sale_salesman",1,1,1,1
-"access_account_invoice_line_agent","access_account_invoice_line_agent","model_account_invoice_line_agent","base.group_sale_salesman",1,1,1,1
+"access_sale_order_line_commission","access_sale_order_line_commission","model_sale_order_line_commission","base.group_sale_salesman",1,1,1,1
+"access_account_invoice_line_commission","access_account_invoice_line_commission","model_account_invoice_line_commission","base.group_sale_salesman",1,1,1,1
 "access_sale_commission_settlement_manager","access_sale_commission_settlement_manager","model_sale_commission_settlement","base.group_sale_manager",1,1,1,1
 "access_sale_commission_settlement_user","access_sale_commission_settlement_manager","model_sale_commission_settlement","base.group_sale_salesman",1,0,0,0
 "access_sale_commission_settlement_line_manager","access_sale_commission_settlement_line_user","model_sale_commission_settlement_line","base.group_sale_manager",1,1,1,1

--- a/sale_commission/tests/__init__.py
+++ b/sale_commission/tests/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import test_periods

--- a/sale_commission/tests/test_periods.py
+++ b/sale_commission/tests/test_periods.py
@@ -1,0 +1,80 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from datetime import date
+
+from openerp.tests import TransactionCase
+
+from ..models.sale_commission import (
+    PERIOD_YEAR,
+    PERIOD_SEMI,
+    PERIOD_QUARTER,
+)
+
+
+class TestPeriodRanges(TransactionCase):
+    """
+    Test period ranges for settlement wizard
+    """
+
+    def setUp(self):
+        super(TestPeriodRanges, self).setUp()
+        self.w = self.env["sale.commission.make.settle"]
+
+    def test_year(self):
+        self.assertEquals(
+            self.w._get_period_start(PERIOD_YEAR, date(2015, 6, 1)),
+            date(2015, 1, 1), "Yearly period start on Jan 1st")
+
+        self.assertEquals(
+            self.w._get_period_end(PERIOD_YEAR, date(2015, 6, 1)),
+            date(2015, 12, 31), "Yearly period ends dec 31st")
+
+    def test_semi(self):
+        self.assertEquals(
+            self.w._get_period_start(PERIOD_SEMI, date(2015, 5, 5)),
+            date(2015, 1, 1), "First semester: Jan-June")
+        self.assertEquals(
+            self.w._get_period_end(PERIOD_SEMI, date(2015, 5, 5)),
+            date(2015, 6, 30), "First semester: Jan-June")
+
+        self.assertEquals(
+            self.w._get_period_start(PERIOD_SEMI, date(2015, 7, 5)),
+            date(2015, 7, 1), "First semester: July-Dec")
+        self.assertEquals(
+            self.w._get_period_end(PERIOD_SEMI, date(2015, 7, 5)),
+            date(2015, 12, 31), "First semester: July-Dec")
+
+    def test_quarter(self):
+        for d, s, e, msg in [
+            (date(2015, 1, 1), date(2015, 1, 1), date(2015, 3, 31),
+             "Q1: Jan-Mar"),
+            (date(2015, 6, 30), date(2015, 4, 1), date(2015, 6, 30),
+             "Q2: Apr-Jun"),
+            (date(2015, 8, 5), date(2015, 7, 1), date(2015, 9, 30),
+             "Q3: Jul-Sep"),
+            (date(2015, 10, 31), date(2015, 10, 1), date(2015, 12, 31),
+             "Q3: Oct-Dec")]:
+            self.assertEquals(self.w._get_period_start(PERIOD_QUARTER, d),
+                              s, msg)
+            self.assertEquals(self.w._get_period_end(PERIOD_QUARTER, d),
+                              e, msg)

--- a/sale_commission/views/account_invoice_view.xml
+++ b/sale_commission/views/account_invoice_view.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
-        <record id="invoice_line_agent_tree" model="ir.ui.view">
-            <field name="name">account.invoice.line.agent.tree</field>
-            <field name="model">account.invoice.line.agent</field>
+        <record id="invoice_line_commission_tree" model="ir.ui.view">
+            <field name="name">account.invoice.line.commission.tree</field>
+            <field name="model">account.invoice.line.commission</field>
             <field name="arch" type="xml">
-                <tree string="Invoice line agents and commissions" editable="bottom">
+                <tree string="Invoice line commissions" editable="bottom">
                     <field name="agent" />
                     <field name="commission" />
                     <field name="amount" />
@@ -13,21 +13,30 @@
             </field>
         </record>
 
-        <record id="invoice_line_form_agent" model="ir.ui.view">
-            <field name="name">account.invoice.line.form.agent</field>
+        <record id="invoice_line_form_commission" model="ir.ui.view">
+            <field name="name">account.invoice.line.form.commission</field>
             <field name="model">account.invoice.line</field>
             <field name="inherit_id" ref="account.view_invoice_line_form" />
             <field name="arch" type="xml">
                 <field name="company_id" position="after">
-                    <field name="commission_free"/>
-                    <field name="agents"
-                           attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                  <field name="commission_free"/>
                 </field>
+                <xpath expr="//label[@for='name']" position="before">
+                  <group string="Commissions" colspan="4" attrs="{'invisible': [('commission_free', '=', True)]}">
+                    <field name="commissions" nolabel="1">
+                      <tree string="Commissions">
+                        <field name="agent" />
+                        <field name="commission" />
+                        <field name="amount" />
+                      </tree>
+                    </field>
+                  </group>
+                </xpath>
             </field>
         </record>
 
-        <record id="invoice_form_agent" model="ir.ui.view">
-            <field name="name">account.invoice.form.agent</field>
+        <record id="invoice_form_commission" model="ir.ui.view">
+            <field name="name">account.invoice.form.commission</field>
             <field name="model">account.invoice</field>
             <field name="inherit_id" ref="account.invoice_form" />
             <field name="arch" type="xml">
@@ -36,7 +45,7 @@
                 </field>
                 <xpath expr="//field[@name='invoice_line']/tree//field[@name='price_subtotal']" position="after">
                     <field name="commission_free"/>
-                    <field name="agents" invisible="1" />
+                    <field name="commissions" invisible="1" />
                 </xpath>
                 <field name="amount_total" position="after">
                     <field name="commission_total"

--- a/sale_commission/views/account_invoice_view.xml
+++ b/sale_commission/views/account_invoice_view.xml
@@ -36,8 +36,7 @@
                 </field>
                 <xpath expr="//field[@name='invoice_line']/tree//field[@name='price_subtotal']" position="after">
                     <field name="commission_free"/>
-                    <field name="agents"
-                           attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                    <field name="agents" invisible="1" />
                 </xpath>
                 <field name="amount_total" position="after">
                     <field name="commission_total"

--- a/sale_commission/views/res_partner_view.xml
+++ b/sale_commission/views/res_partner_view.xml
@@ -23,12 +23,23 @@
                         <group>
                             <group>
                                 <field name="agent_type"/>
-                                <field name="commission"
-                                       attrs="{'required': [('agent', '=', True)]}"/>
                             </group>
                             <group>
                                 <field name="settlement"/>
                             </group>
+                            <group string="Commissions" colspan="4">
+                                <field name="commissions" nolabel="1">
+                                    <tree string="Commissions">
+                                        <field name="name" />
+                                        <field name="period" />
+                                        <field name="commission_type" />
+                                        <field name="fix_qty" />
+                                        <field name="sections" />
+                                        <field name="scope" />
+                                    </tree>
+                                </field>
+                            </group>
+
                             <group colspan="4"
                                    string="Settlements">
                                 <field name="settlements" nolabel="1">

--- a/sale_commission/views/sale_commission_view.xml
+++ b/sale_commission/views/sale_commission_view.xml
@@ -25,6 +25,8 @@
                         </group>
                         <group>
                             <field name="commission_type" />
+                            <field name="period" />
+                            <field name="scope" />
                         </group>
                     </group>
                     <group string="Rates definition" colspan="4">

--- a/sale_commission/views/sale_order_view.xml
+++ b/sale_commission/views/sale_order_view.xml
@@ -12,11 +12,11 @@
                 </field>
                 <xpath expr="//field[@name='order_line']/tree//field[@name='price_subtotal']" position="after">
                     <field name="commission_free"/>
-                    <field name="agents" invisible="1" />
+                    <field name="commissions" invisible="1" />
                 </xpath>
                 <xpath expr="//field[@name='order_line']/form//field[@name='address_allotment_id']" position="after">
                     <field name="commission_free"/>
-                    <field name="agents" invisible="1" />
+                    <field name="commissions" invisible="1" />
                 </xpath>
                 <field name="amount_total" position="after">
                     <field name="commission_total"
@@ -27,12 +27,13 @@
         </record>
 
         <record model="ir.ui.view" id="view_sale_order_line_tree">
-            <field name="name">sale.order.line.agent.tree</field>
-            <field name="model">sale.order.line.agent</field>
+            <field name="name">sale.order.line.commission.tree</field>
+            <field name="model">sale.order.line.commission</field>
             <field name="arch" type="xml">
-                <tree string="Agents" editable="bottom">
-                    <field name="agent"/>
-                    <field name="commission"/>
+                <tree string="Commissions" editable="bottom">
+                    <field name="agent" />
+                    <field name="commission" />
+                    <field name="amount" />
                 </tree>
             </field>
         </record>

--- a/sale_commission/views/sale_order_view.xml
+++ b/sale_commission/views/sale_order_view.xml
@@ -12,13 +12,11 @@
                 </field>
                 <xpath expr="//field[@name='order_line']/tree//field[@name='price_subtotal']" position="after">
                     <field name="commission_free"/>
-                    <field name="agents"
-                           attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                    <field name="agents" invisible="1" />
                 </xpath>
                 <xpath expr="//field[@name='order_line']/form//field[@name='address_allotment_id']" position="after">
                     <field name="commission_free"/>
-                    <field name="agents"
-                           attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                    <field name="agents" invisible="1" />
                 </xpath>
                 <field name="amount_total" position="after">
                     <field name="commission_total"

--- a/sale_commission/wizard/wizard_settle.py
+++ b/sale_commission/wizard/wizard_settle.py
@@ -83,7 +83,7 @@ class SaleCommissionMakeSettle(models.TransientModel):
     @api.multi
     def action_settle(self):
         self.ensure_one()
-        agent_line_obj = self.env['account.invoice.line.agent']
+        commission_line_obj = self.env['account.invoice.line.commission']
         settlement_obj = self.env['sale.commission.settlement']
         settlement_line_obj = self.env['sale.commission.settlement.line']
         if not self.agents:
@@ -94,7 +94,7 @@ class SaleCommissionMakeSettle(models.TransientModel):
             agent_period = agent.settlement
             date_to_agent = self._get_period_start(agent_period, date_to)
             # Get non settled invoices
-            commission_lines = agent_line_obj.search(
+            commission_lines = commission_line_obj.search(
                 [('invoice_date', '<', date_to_agent),
                  ('agent', '=', agent.id),
                  ('settled', '=', False)], order='invoice_date')

--- a/sale_commission/wizard/wizard_settle.py
+++ b/sale_commission/wizard/wizard_settle.py
@@ -132,6 +132,6 @@ class SaleCommissionMakeSettle(models.TransientModel):
 
                     settlement_line_obj.create(
                         {'settlement': settlement.id,
-                         'agent_line': [(6, 0, [line.id])]})
+                         'commission_line': [(6, 0, [line.id])]})
 
         return True

--- a/sale_commission/wizard/wizard_settle.py
+++ b/sale_commission/wizard/wizard_settle.py
@@ -24,6 +24,13 @@ from openerp import models, fields, api, exceptions, _
 from datetime import date, timedelta
 from dateutil.relativedelta import relativedelta
 
+from ..models.sale_commission import (
+    PERIOD_MONTH,
+    PERIOD_QUARTER,
+    PERIOD_SEMI,
+    PERIOD_YEAR,
+)
+
 
 class SaleCommissionMakeSettle(models.TransientModel):
     _name = "sale.commission.make.settle"
@@ -32,35 +39,43 @@ class SaleCommissionMakeSettle(models.TransientModel):
     agents = fields.Many2many(comodel_name='res.partner',
                               domain="[('agent', '=', True)]")
 
-    def _get_period_start(self, agent, date_to):
+    @classmethod
+    def _get_period_start(cls, period, date_to):
         if isinstance(date_to, basestring):
             date_to = fields.Date.from_string(date_to)
-        if agent.settlement == 'monthly':
+        if period == PERIOD_MONTH:
             return date(month=date_to.month, year=date_to.year, day=1)
-        elif agent.settlement == 'quaterly':
+        elif period == PERIOD_QUARTER:
             # Get first month of the date quarter
-            month = ((date_to.month - 1) // 3 + 1) * 3
+            month = ((date_to.month - 1) // 3) * 3 + 1
             return date(month=month, year=date_to.year, day=1)
-        elif agent.settlement == 'semi':
+        elif period == PERIOD_SEMI:
             if date_to.month > 6:
                 return date(month=7, year=date_to.year, day=1)
             else:
                 return date(month=1, year=date_to.year, day=1)
-        elif agent.settlement == 'annual':
+        elif period == PERIOD_YEAR:
             return date(month=1, year=date_to.year, day=1)
         else:
             raise exceptions.Warning(_("Settlement period not valid."))
 
-    def _get_next_period_date(self, agent, current_date):
+    @classmethod
+    def _get_period_end(cls, period, date):
+        start = cls._get_period_start(period, date)
+        end = cls._get_next_period_date(period, start) - relativedelta(days=1)
+        return end
+
+    @classmethod
+    def _get_next_period_date(cls, period, current_date):
         if isinstance(current_date, basestring):
             current_date = fields.Date.from_string(current_date)
-        if agent.settlement == 'monthly':
+        if period == PERIOD_MONTH:
             return current_date + relativedelta(months=1)
-        elif agent.settlement == 'quaterly':
+        elif period == PERIOD_QUARTER:
             return current_date + relativedelta(months=3)
-        elif agent.settlement == 'semi':
+        elif period == PERIOD_SEMI:
             return current_date + relativedelta(months=6)
-        elif agent.settlement == 'annual':
+        elif period == PERIOD_YEAR:
             return current_date + relativedelta(years=1)
         else:
             raise exceptions.Warning(_("Settlement period not valid."))
@@ -76,30 +91,47 @@ class SaleCommissionMakeSettle(models.TransientModel):
                 [('agent', '=', True)])
         date_to = fields.Date.from_string(self.date_to)
         for agent in self.agents:
-            date_to_agent = self._get_period_start(agent, date_to)
+            agent_period = agent.settlement
+            date_to_agent = self._get_period_start(agent_period, date_to)
             # Get non settled invoices
-            agent_lines = agent_line_obj.search(
+            commission_lines = agent_line_obj.search(
                 [('invoice_date', '<', date_to_agent),
                  ('agent', '=', agent.id),
                  ('settled', '=', False)], order='invoice_date')
-            if agent_lines:
-                pos = 0
-                sett_to = fields.Date.to_string(date(year=1900, month=1,
-                                                     day=1))
-                while pos < len(agent_lines):
-                    if agent_lines[pos].invoice_date > sett_to:
-                        sett_from = self._get_period_start(
-                            agent, agent_lines[pos].invoice_date)
-                        sett_to = fields.Date.to_string(
-                            self._get_next_period_date(agent, sett_from) -
+
+            if not commission_lines:
+                # Nothing to settle, carry on
+                continue
+            # Group lines according to period types
+            periods = {}
+            for line in commission_lines:
+                periods.setdefault(line.commission.period, []).append(line)
+
+            # Go through each period type, creating settlements as required
+            for period, lines in periods.items():
+                sett_to = date(year=1900, month=1, day=1)
+                sett_to_str = fields.Date.to_string(sett_to)
+                for line in lines:
+                    if line.invoice_date > sett_to_str:
+                        sett_from = self._get_period_start(period,
+                                                           line.invoice_date)
+                        sett_to = (
+                            self._get_next_period_date(period, sett_from) -
                             timedelta(days=1))
+                        sett_to_str = fields.Date.to_string(sett_to)
+
+                        # Do not allow settling unfinished periods
+                        if sett_to >= date_to:
+                            break
+
                         sett_from = fields.Date.to_string(sett_from)
                         settlement = settlement_obj.create(
                             {'agent': agent.id,
                              'date_from': sett_from,
-                             'date_to': sett_to})
+                             'date_to': sett_to_str})
+
                     settlement_line_obj.create(
                         {'settlement': settlement.id,
-                         'agent_line': [(6, 0, [agent_lines[pos].id])]})
-                    pos += 1
+                         'agent_line': [(6, 0, [line.id])]})
+
         return True


### PR DESCRIPTION
This is part of #27 and is rebased on #28 and #29.

This update allows agents to have multiple commissions, such as a quarterly company sales commission and monthly own sales.

Yes, some fields were renamed. I think while we have a migration to do in any case, it is worthwhile to move into "clean" names that represent the new state of things.
