### PR TITLE
[FIX] sale.commission.settlement access error opening res.partner for…

### DIFF
--- a/sale_commission/views/res_partner_view.xml
+++ b/sale_commission/views/res_partner_view.xml
@@ -7,6 +7,7 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form" />
             <field name="priority" eval="18"/>
+            <field name="groups_id" eval="[(4, ref('base.group_sale_salesman'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//page[@name='sales_purchases']//field[@name='supplier']" position="after">
                     <field name="agent" string="Agent" />


### PR DESCRIPTION
…m for users w/o sale rights

Users without sales rights can still open the res.partner form -eg. trough Messaging->Organizer->Contacts- but doing so with sale_commission module installed rises a "not enough rights error" for sale.commission.settlement.
This fix solves the error hiding all the commission fields to users without basic sale rights
