### PR TITLE
[FIX] "sale" journal type on making agent invoice

### DIFF
--- a/sale_commission/wizard/wizard_invoice.py
+++ b/sale_commission/wizard/wizard_invoice.py
@@ -27,7 +27,7 @@ class SaleCommissionMakeInvoice(models.TransientModel):
 
     def _default_journal(self):
         return self.env['account.journal'].search(
-        	[('type', '=', 'purchase')])[0]
+            [('type', '=', 'purchase')])[0]
 
     def _default_settlements(self):
         return self.env.context.get('settlement_ids', [])

--- a/sale_commission/wizard/wizard_invoice.py
+++ b/sale_commission/wizard/wizard_invoice.py
@@ -26,7 +26,7 @@ class SaleCommissionMakeInvoice(models.TransientModel):
     _name = 'sale.commission.make.invoice'
 
     def _default_journal(self):
-        return self.env['account.journal'].search([('type', '=', 'sale')])[0]
+        return self.env['account.journal'].search([('type', '=', 'purchase')])[0]
 
     def _default_settlements(self):
         return self.env.context.get('settlement_ids', [])
@@ -36,7 +36,7 @@ class SaleCommissionMakeInvoice(models.TransientModel):
 
     journal = fields.Many2one(
         comodel_name='account.journal', required=True,
-        domain="[('type', '=', 'sale')]", default=_default_journal)
+        domain="[('type', '=', 'purchase')]", default=_default_journal)
     product = fields.Many2one(
         comodel_name='product.product', string='Product for invoicing',
         required=True)

--- a/sale_commission/wizard/wizard_invoice.py
+++ b/sale_commission/wizard/wizard_invoice.py
@@ -26,7 +26,8 @@ class SaleCommissionMakeInvoice(models.TransientModel):
     _name = 'sale.commission.make.invoice'
 
     def _default_journal(self):
-        return self.env['account.journal'].search([('type', '=', 'purchase')])[0]
+        return self.env['account.journal'].search(
+        	[('type', '=', 'purchase')])[0]
 
     def _default_settlements(self):
         return self.env.context.get('settlement_ids', [])


### PR DESCRIPTION
On generate agent invoice you can only select journal of type "sale". This can cause the numbers of sales invoices not correlated.
IMHO, agent invoices must be of type purchase and this solves it, allowing to select journals of type purchase.
