### PR TITLE
8.0 sale commission multiple

### DIFF
--- a/hr_commission/views/res_partner_view.xml
+++ b/hr_commission/views/res_partner_view.xml
@@ -7,7 +7,7 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="sale_commission.view_partner_form_agent" />
             <field name="arch" type="xml">
-                <field name="commission" position="after">
+                <field name="agent_type" position="after">
                     <field name="employee"
                            attrs="{'invisible': [('agent_type', '!=', 'salesman')]}" />
                 </field>

--- a/sale_commission/__openerp__.py
+++ b/sale_commission/__openerp__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 {
     'name': 'Sales commissions',
-    'version': '2.0',
+    'version': '2.1',
     'author': 'Pexego, '
               'Savoire-faire linux, '
               'Avanzosc, '
@@ -45,6 +45,7 @@
         "Giorgio Borelli <giorgio.borelli@abstract.it>",
         "Daniel Campos <danielcampos@avanzosc.es>",
         "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
+        "Vincent Vinet <vincent.vinet@savoirfairelinux.com>",
     ],
     "data": [
         "security/ir.model.access.csv",
@@ -56,7 +57,6 @@
         "views/settlement_view.xml",
         "wizard/wizard_settle.xml",
         "wizard/wizard_invoice.xml",
-        # "report/cc_commission_report.xml"
     ],
     "demo": [
         # 'demo/sale_agent_demo.xml',

--- a/sale_commission/models/__init__.py
+++ b/sale_commission/models/__init__.py
@@ -19,9 +19,9 @@
 #
 ##############################################################################
 
+from . import account_invoice
 from . import product_template
 from . import sale_commission
 from . import res_partner
 from . import sale_order
-from . import account_invoice
 from . import settlement

--- a/sale_commission/models/account_invoice.py
+++ b/sale_commission/models/account_invoice.py
@@ -28,11 +28,11 @@ class AccountInvoice(models.Model):
     _inherit = "account.invoice"
 
     @api.one
-    @api.depends('invoice_line.agents.amount')
+    @api.depends('invoice_line.commissions.amount')
     def _get_commission_total(self):
         self.commission_total = 0.0
         for line in self.invoice_line:
-            self.commission_total += sum(x.amount for x in line.agents)
+            self.commission_total += sum(x.amount for x in line.commissions)
         # Consider also purchase refunds, although not in the initial scope
         if self.type in ('out_refund', 'in_refund'):
             self.commission_total = -self.commission_total
@@ -70,34 +70,36 @@ class AccountInvoice(models.Model):
 
 
 class AccountInvoiceLine(models.Model):
+    """Invoice Line inherit to add commissions"""
     _inherit = "account.invoice.line"
 
     @api.model
-    def _default_agents(self):
-        agents = []
-        if self.env.context.get('partner_id'):
-            partner = self.env['res.partner'].browse(
-                self.env.context['partner_id'])
-            for agent in partner.agents:
-                agents.append({'agent': agent.id,
-                               'commission': agent.commission.id})
-        return [(0, 0, x) for x in agents]
+    def _default_commissions(self):
+        res = self.env['sale.commission'].get_default_commissions()
+        return [(0, 0, x) for x in res]
 
-    agents = fields.One2many(
-        comodel_name="account.invoice.line.agent",
+    commissions = fields.One2many(
+        comodel_name="account.invoice.line.commission",
         inverse_name="invoice_line", string="Agents & commissions",
         help="Agents/Commissions related to the invoice line.",
-        default=_default_agents, copy=True)
+        default=_default_commissions, copy=True)
     commission_free = fields.Boolean(
         string="Comm. free", related="product_id.commission_free",
         store=True, readonly=True)
 
 
-class AccountInvoiceLineAgent(models.Model):
-    _name = "account.invoice.line.agent"
+class AccountInvoiceLineAgentCommission(models.Model):
+    _name = "account.invoice.line.commission"
+    _description = "Commissions to be paid on an invoice line"
 
     invoice_line = fields.Many2one(
         comodel_name="account.invoice.line", required=True, ondelete="cascade")
+    commission = fields.Many2one(
+        comodel_name="sale.commission", required=True, ondelete="restrict")
+    agent = fields.Many2one(
+        comodel_name="res.partner", required=True, ondelete="restrict",
+        domain="[('agent', '=', True)]")
+
     invoice = fields.Many2one(
         comodel_name="account.invoice", string="Invoice",
         related="invoice_line.invoice_id", store=True)
@@ -106,47 +108,34 @@ class AccountInvoiceLineAgent(models.Model):
         readonly=True)
     product = fields.Many2one(
         comodel_name='product.product', related="invoice_line.product_id")
-    agent = fields.Many2one(
-        comodel_name="res.partner", required=True, ondelete="restrict",
-        domain="[('agent', '=', True)]")
-    commission = fields.Many2one(
-        comodel_name="sale.commission", required=True, ondelete="restrict")
     amount = fields.Float(
         string="Amount settled", compute="_get_amount", store=True)
-    agent_line = fields.Many2many(
-        comodel_name='sale.commission.settlement.line',
-        relation='settlement_agent_line_rel', column1='agent_line_id',
-        column2='settlement_id')
     settled = fields.Boolean(compute="_get_settled", store=True)
+    settlement_id = fields.Many2one("sale.commission.settlement")
 
-    @api.one
-    @api.onchange('agent')
-    def onchange_agent(self):
-        self.commission = self.agent.commission
 
     @api.one
     @api.depends('commission.commission_type', 'invoice_line.price_subtotal')
     def _get_amount(self):
         self.amount = 0.0
-        if (not self.invoice_line.product_id.commission_free and
-                self.commission):
-            subtotal = self.invoice_line.price_subtotal
-            if self.commission.commission_type == 'fixed':
-                self.amount = subtotal * (self.commission.fix_qty / 100.0)
-            else:
-                self.amount = self.commission.calculate_section(subtotal)
+        if self.commission:
+            self.amount = self.commission.compute_invoice_commission(
+                self.invoice_line)
 
     @api.one
-    @api.depends('agent_line', 'agent_line.settlement.state', 'invoice',
-                 'invoice.state')
+    @api.depends('settlement_id', 'settlement_id.state',
+                 'invoice', 'invoice.state')
     def _get_settled(self):
-        # Count lines of not open or paid invoices as settled for not
-        # being included in settlements
-        self.settled = (self.invoice.state not in ('open', 'paid') or
-                        any(x.settlement.state != 'cancel'
-                            for x in self.agent_line))
+        # Count as settled if either:
+        # - our invoice isn't open or paid (nothing to settle)
+        # - we have a settled or invoiced settlement
+        self.settled = bool(
+            self.invoice.state not in ('open', 'paid') or
+            self.settlement_id and
+            self.settlement_id.state in ('settled', 'invoiced')
+        )
 
     _sql_constraints = [
-        ('unique_agent', 'UNIQUE(invoice_line, agent)',
-         'You can only add one time each agent.')
+        ('unique_agent', 'UNIQUE(invoice_line, agent, commission)',
+         'You can only add one time per commission per agent.')
     ]

--- a/sale_commission/models/account_invoice.py
+++ b/sale_commission/models/account_invoice.py
@@ -113,7 +113,6 @@ class AccountInvoiceLineAgentCommission(models.Model):
     settled = fields.Boolean(compute="_get_settled", store=True)
     settlement_id = fields.Many2one("sale.commission.settlement")
 
-
     @api.one
     @api.depends('commission.commission_type', 'invoice_line.price_subtotal')
     def _get_amount(self):

--- a/sale_commission/models/res_partner.py
+++ b/sale_commission/models/res_partner.py
@@ -22,6 +22,8 @@
 ##############################################################################
 from openerp import models, fields, api
 
+from . import sale_commission as sc
+
 
 class ResPartner(models.Model):
     """Add some fields related to commissions"""
@@ -38,16 +40,18 @@ class ResPartner(models.Model):
     agent_type = fields.Selection(
         selection=[("agent", "External agent")], string="Type", required=True,
         default="agent")
-    commission = fields.Many2one(
+    commissions = fields.Many2many(
         string="Commission", comodel_name="sale.commission",
+        relation="agent_commission_rel",
+        column1="partner_id", column2="commission_id",
         help="This is the default commission used in the sales where this "
              "agent is assigned. It can be changed on each operation if "
              "needed.")
     settlement = fields.Selection(
-        selection=[("monthly", "Monthly"),
-                   ("quaterly", "Quarterly"),
-                   ("semi", "Semi-annual"),
-                   ("annual", "Annual")],
+        selection=[(sc.PERIOD_MONTH, "Monthly"),
+                   (sc.PERIOD_QUARTER, "Quarterly"),
+                   (sc.PERIOD_SEMI, "Semi-annual"),
+                   (sc.PERIOD_YEAR, "Annual")],
         string="Settlement period", default="monthly", required=True)
     settlements = fields.One2many(
         comodel_name="sale.commission.settlement", inverse_name="agent",

--- a/sale_commission/models/sale_commission.py
+++ b/sale_commission/models/sale_commission.py
@@ -84,7 +84,7 @@ class SaleCommission(models.Model):
             )
         return self.compute_commission(
             sale_line.product_id,
-            sale_line.price_subtotal,
+            base,
         )
 
     # Currently implementation is the same, use same function. Both provided

--- a/sale_commission/models/sale_commission.py
+++ b/sale_commission/models/sale_commission.py
@@ -80,16 +80,27 @@ class SaleCommission(models.Model):
         elif self.scope in ("own_margin", "company_margin"):
             # Compute margin: subtotal - unit cost * qty
             base = sale_line.price_subtotal - (
-                sale_line.product_id.standard_price * sale_line.quantity
+                sale_line.product_id.standard_price * sale_line.product_uom_qty
             )
         return self.compute_commission(
             sale_line.product_id,
             base,
         )
 
-    # Currently implementation is the same, use same function. Both provided
-    # to avoid breakage if we need different fields in invoice and SO
-    compute_invoice_commission = compute_sale_commission
+    @api.multi
+    def compute_invoice_commission(self, invoice_line):
+        """ Compute the commission on a sale order line """
+        if self.scope in ("own_sales", "company_sales"):
+            base = invoice_line.price_subtotal
+        elif self.scope in ("own_margin", "company_margin"):
+            # Compute margin: subtotal - unit cost * qty
+            base = invoice_line.price_subtotal - (
+                invoice_line.product_id.standard_price * invoice_line.quantity
+            )
+        return self.compute_commission(
+            invoice_line.product_id,
+            base,
+        )
 
     @api.multi
     def compute_commission(self, product_id, price_subtotal):

--- a/sale_commission/models/sale_commission.py
+++ b/sale_commission/models/sale_commission.py
@@ -89,7 +89,7 @@ class SaleCommission(models.Model):
 
     @api.multi
     def compute_invoice_commission(self, invoice_line):
-        """ Compute the commission on a sale order line """
+        """ Compute the commission on a invoice line """
         if self.scope in ("own_sales", "company_sales"):
             base = invoice_line.price_subtotal
         elif self.scope in ("own_margin", "company_margin"):

--- a/sale_commission/models/sale_commission.py
+++ b/sale_commission/models/sale_commission.py
@@ -23,6 +23,12 @@
 from openerp import models, fields, api, exceptions, _
 
 
+PERIOD_MONTH = "monthly"
+PERIOD_QUARTER = "quaterly"
+PERIOD_SEMI = "semi"
+PERIOD_YEAR = "annual"
+
+
 class SaleCommission(models.Model):
     _name = "sale.commission"
     _description = "Commission in sales"
@@ -36,6 +42,62 @@ class SaleCommission(models.Model):
     sections = fields.One2many(
         comodel_name="sale.commission.section", inverse_name="commission")
     active = fields.Boolean(default=True)
+    period = fields.Selection(
+        selection=[(PERIOD_MONTH, "Monthly"),
+                   (PERIOD_QUARTER, "Every quarter"),
+                   (PERIOD_SEMI, "Every semester"),
+                   (PERIOD_YEAR, "Every year")],
+        required=True, default=PERIOD_MONTH,
+    )
+    scope = fields.Selection(
+        selection=[("own_sales", "On his customer sales"),
+                   ("company_sales", "On company sales"),
+                   ("own_margin", "On his customers margin"),
+                   ("company_margin", "On company margin")],
+        required=True, default="own_sales",
+    )
+
+    def has_company_scope(self):
+        return self.scope in ("company_sales", "company_margin")
+
+    def has_own_scope(self):
+        return self.scope in ("own_sales", "own_margin")
+
+    agent_ids = fields.Many2many(
+        string="Agents", comodel_name="res.partner",
+        relation="agent_commission_rel",
+        column2="partner_id", column1="commission_id",
+    )
+
+    @api.multi
+    def compute_sale_commission(self, sale_line):
+        """ Compute the commission on a sale order line """
+        if self.scope in ("own_sales", "company_sales"):
+            base = sale_line.price_subtotal
+        elif self.scope in ("own_margin", "company_margin"):
+            # Compute margin: subtotal - unit cost * qty
+            base = sale_line.price_subtotal - (
+                sale_line.product_id.standard_price * sale_line.quantity
+            )
+        return self.compute_commission(
+            sale_line.product_id,
+            sale_line.price_subtotal,
+        )
+
+    # Currently implementation is the same, use same function. Both provided
+    # to avoid breakage if we need different fields in invoice and SO
+    compute_invoice_commission = compute_sale_commission
+
+    @api.multi
+    def compute_commission(self, product_id, price_subtotal):
+        self.ensure_one()
+        if product_id.commission_free:
+            return 0.0
+
+        if self.commission_type == 'fixed':
+            return price_subtotal * (self.fix_qty / 100.0)
+        elif self.commission_type == 'section':
+            return self.calculate_section(price_subtotal)
 
     @api.multi
     def calculate_section(self, base):
@@ -44,6 +106,31 @@ class SaleCommission(models.Model):
             if section.amount_from <= base <= section.amount_to:
                 return base * section.percent / 100.0
         return 0.0
+
+    def get_default_commissions(self):
+        partner_obj = self.env['res.partner']
+        res = []
+        if self.env.context.get('partner_id'):
+            partner = partner_obj.browse(
+                self.env.context['partner_id'])
+            for agent in partner.agents:
+                res.extend(
+                    {'agent': agent.id,
+                     'commission': comm.id}
+                    for comm in agent.commissions
+                    if comm.has_own_scope()
+                )
+            for agent in partner_obj.search(
+                    [('company_id', '=', partner.company_id.id),
+                     ('agent', '=', True)]):
+                res.extend(
+                    {'agent': agent.id,
+                     'commission': comm.id}
+                    for comm in agent.commissions
+                    if comm.has_company_scope()
+                )
+
+        return res
 
 
 class SaleCommissionSection(models.Model):

--- a/sale_commission/models/sale_order.py
+++ b/sale_commission/models/sale_order.py
@@ -49,7 +49,7 @@ class SaleOrderLine(models.Model):
     commissions = fields.One2many(
         string="Agents & commissions",
         comodel_name='sale.order.line.commission', inverse_name='sale_line',
-        copy=True, readonly=True, default=_default_commissions)
+        copy=True, default=_default_commissions)
     commission_free = fields.Boolean(
         string="Comm. free", related="product_id.commission_free",
         store=True, readonly=True)

--- a/sale_commission/models/sale_order.py
+++ b/sale_commission/models/sale_order.py
@@ -27,11 +27,11 @@ class SaleOrder(models.Model):
     _inherit = "sale.order"
 
     @api.one
-    @api.depends('order_line.agents.amount')
+    @api.depends('order_line.commissions.amount')
     def _get_commission_total(self):
         self.commission_total = 0.0
         for line in self.order_line:
-            self.commission_total += sum(x.amount for x in line.agents)
+            self.commission_total += sum(x.amount for x in line.commissions)
 
     commission_total = fields.Float(
         string="Commissions", compute="_get_commission_total",
@@ -42,20 +42,14 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     @api.model
-    def _default_agents(self):
-        agents = []
-        if self.env.context.get('partner_id'):
-            partner = self.env['res.partner'].browse(
-                self.env.context['partner_id'])
-            for agent in partner.agents:
-                agents.append({'agent': agent.id,
-                               'commission': agent.commission.id})
-        return [(0, 0, x) for x in agents]
+    def _default_commissions(self):
+        res = self.env['sale.commission'].get_default_commissions()
+        return [(0, 0, x) for x in res]
 
-    agents = fields.One2many(
+    commissions = fields.One2many(
         string="Agents & commissions",
-        comodel_name='sale.order.line.agent', inverse_name='sale_line',
-        copy=True, readonly=True, default=_default_agents)
+        comodel_name='sale.order.line.commission', inverse_name='sale_line',
+        copy=True, readonly=True, default=_default_commissions)
     commission_free = fields.Boolean(
         string="Comm. free", related="product_id.commission_free",
         store=True, readonly=True)
@@ -64,14 +58,15 @@ class SaleOrderLine(models.Model):
     def _prepare_order_line_invoice_line(self, line, account_id=False):
         vals = super(SaleOrderLine, self)._prepare_order_line_invoice_line(
             line, account_id=account_id)
-        vals['agents'] = [
-            (0, 0, {'agent': x.agent.id,
-                    'commission': x.commission.id}) for x in line.agents]
+        vals['commissions'] = [
+            (0, 0, {'agent': c.agent.id,
+                    'commission': c.commission.id})
+            for c in line.commissions]
         return vals
 
 
-class SaleOrderLineAgent(models.Model):
-    _name = "sale.order.line.agent"
+class SaleOrderLineCommission(models.Model):
+    _name = "sale.order.line.commission"
     _rec_name = "agent"
 
     sale_line = fields.Many2one(
@@ -84,23 +79,14 @@ class SaleOrderLineAgent(models.Model):
     amount = fields.Float(compute="_get_amount", store=True)
 
     _sql_constraints = [
-        ('unique_agent', 'UNIQUE(sale_line, agent)',
-         'You can only add one time each agent.')
+        ('unique_agent', 'UNIQUE(sale_line, agent, commission)',
+         'You can only add one of each commission for each agent.')
     ]
-
-    @api.one
-    @api.onchange('agent')
-    def onchange_agent(self):
-        self.commission = self.agent.commission
 
     @api.one
     @api.depends('commission.commission_type', 'sale_line.price_subtotal')
     def _get_amount(self):
         self.amount = 0.0
-        if (not self.sale_line.product_id.commission_free and
-                self.commission):
-            subtotal = self.sale_line.price_subtotal
-            if self.commission.commission_type == 'fixed':
-                self.amount = subtotal * (self.commission.fix_qty / 100.0)
-            else:
-                self.amount = self.commission.calculate_section(subtotal)
+        if self.commission:
+            self.amount = self.commission.compute_sale_commission(
+                self.sale_line)

--- a/sale_commission/models/settlement.py
+++ b/sale_commission/models/settlement.py
@@ -67,8 +67,8 @@ class Settlement(models.Model):
         date_to = fields.Date.from_string(self.date_to)
         self.name = "{0} [{1} - {2}]".format(
             self.agent.name,
-            self.date_from,
-            self.date_to,
+            date_from,
+            date_to,
         )
 
     @api.multi

--- a/sale_commission/models/settlement.py
+++ b/sale_commission/models/settlement.py
@@ -52,7 +52,6 @@ class Settlement(models.Model):
         comodel_name='res.currency', readonly=True,
         default=_default_currency)
 
-
     @api.one
     @api.depends('lines', 'lines.amount')
     def _get_total(self):
@@ -187,6 +186,6 @@ class SettlementLine(models.Model):
                         ON settlement.id = comm_line.settlement_id
             )
             """.format(
-                table = self._table,
+                table=self._table,
             ),
         )

--- a/sale_commission/security/ir.model.access.csv
+++ b/sale_commission/security/ir.model.access.csv
@@ -3,9 +3,8 @@
 "access_sale_commission_user","access_sale_commission_user","model_sale_commission","base.group_sale_salesman",1,0,0,0
 "access_sale_commission_section_manager","access_sale_commission_section_manager","model_sale_commission_section","base.group_sale_manager",1,1,1,1
 "access_sale_commission_section_user","access_sale_commission_section_user","model_sale_commission_section","base.group_sale_salesman",1,0,0,0
-"access_sale_order_line_agent","access_sale_order_line_agent","model_sale_order_line_agent","base.group_sale_salesman",1,1,1,1
-"access_account_invoice_line_agent","access_account_invoice_line_agent","model_account_invoice_line_agent","base.group_sale_salesman",1,1,1,1
+"access_sale_order_line_commission","access_sale_order_line_commission","model_sale_order_line_commission","base.group_sale_salesman",1,1,1,1
+"access_account_invoice_line_commission","access_account_invoice_line_commission","model_account_invoice_line_commission","base.group_sale_salesman",1,1,1,1
 "access_sale_commission_settlement_manager","access_sale_commission_settlement_manager","model_sale_commission_settlement","base.group_sale_manager",1,1,1,1
 "access_sale_commission_settlement_user","access_sale_commission_settlement_manager","model_sale_commission_settlement","base.group_sale_salesman",1,0,0,0
-"access_sale_commission_settlement_line_manager","access_sale_commission_settlement_line_user","model_sale_commission_settlement_line","base.group_sale_manager",1,1,1,1
 "access_sale_commission_settlement_line_user","access_sale_commission_settlement_line_user","model_sale_commission_settlement_line","base.group_sale_salesman",1,0,0,0

--- a/sale_commission/tests/__init__.py
+++ b/sale_commission/tests/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import test_periods

--- a/sale_commission/tests/test_periods.py
+++ b/sale_commission/tests/test_periods.py
@@ -20,7 +20,7 @@
 #
 ##############################################################################
 
-from datetime import date, timedelta
+from datetime import date
 
 from openerp.tests import TransactionCase
 

--- a/sale_commission/tests/test_periods.py
+++ b/sale_commission/tests/test_periods.py
@@ -1,0 +1,76 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from datetime import date, timedelta
+
+from openerp.tests import TransactionCase
+
+from ..models import sale_commission as sc
+
+
+class TestPeriodRanges(TransactionCase):
+    """
+    Test period ranges for settlement wizard
+    """
+
+    def setUp(self):
+        super(TestPeriodRanges, self).setUp()
+        self.w = self.env["sale.commission.make.settle"]
+
+    def test_year(self):
+        self.assertEquals(
+            self.w._get_period_start(sc.PERIOD_YEAR, date(2015, 6, 1)),
+            date(2015, 1, 1), "Yearly period start on Jan 1st")
+
+        self.assertEquals(
+            self.w._get_period_end(sc.PERIOD_YEAR, date(2015, 6, 1)),
+            date(2015, 12, 31), "Yearly period ends dec 31st")
+
+    def test_semi(self):
+        self.assertEquals(
+            self.w._get_period_start(sc.PERIOD_SEMI, date(2015, 5, 5)),
+            date(2015, 1, 1), "First semester: Jan-June")
+        self.assertEquals(
+            self.w._get_period_end(sc.PERIOD_SEMI, date(2015, 5, 5)),
+            date(2015, 6, 30), "First semester: Jan-June")
+
+        self.assertEquals(
+            self.w._get_period_start(sc.PERIOD_SEMI, date(2015, 7, 5)),
+            date(2015, 7, 1), "First semester: July-Dec")
+        self.assertEquals(
+            self.w._get_period_end(sc.PERIOD_SEMI, date(2015, 7, 5)),
+            date(2015, 12, 31), "First semester: July-Dec")
+
+    def test_quarter(self):
+        for d, s, e, msg in [
+            (date(2015, 1, 1), date(2015, 1, 1), date(2015, 3, 31),
+             "Q1: Jan-Mar"),
+            (date(2015, 6, 30), date(2015, 4, 1), date(2015, 6, 30),
+             "Q2: Apr-Jun"),
+            (date(2015, 8, 5), date(2015, 7, 1), date(2015, 9, 30),
+             "Q3: Jul-Sep"),
+            (date(2015, 10, 31), date(2015, 10, 1), date(2015, 12, 31),
+             "Q3: Oct-Dec")]:
+            self.assertEquals(self.w._get_period_start(sc.PERIOD_QUARTER, d),
+                              s, msg)
+            self.assertEquals(self.w._get_period_end(sc.PERIOD_QUARTER, d),
+                              e, msg)

--- a/sale_commission/views/account_invoice_view.xml
+++ b/sale_commission/views/account_invoice_view.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
-        <record id="invoice_line_agent_tree" model="ir.ui.view">
-            <field name="name">account.invoice.line.agent.tree</field>
-            <field name="model">account.invoice.line.agent</field>
+        <record id="invoice_line_commission_tree" model="ir.ui.view">
+            <field name="name">account.invoice.line.commission.tree</field>
+            <field name="model">account.invoice.line.commission</field>
             <field name="arch" type="xml">
-                <tree string="Invoice line agents and commissions" editable="bottom">
+                <tree string="Invoice line commissions and commissions" editable="bottom">
                     <field name="agent" />
                     <field name="commission" />
                     <field name="amount" />
@@ -13,21 +13,21 @@
             </field>
         </record>
 
-        <record id="invoice_line_form_agent" model="ir.ui.view">
-            <field name="name">account.invoice.line.form.agent</field>
+        <record id="invoice_line_form_commission" model="ir.ui.view">
+            <field name="name">account.invoice.line.form.commission</field>
             <field name="model">account.invoice.line</field>
             <field name="inherit_id" ref="account.view_invoice_line_form" />
             <field name="arch" type="xml">
                 <field name="company_id" position="after">
                     <field name="commission_free"/>
-                    <field name="agents"
+                    <field name="commissions"
                            attrs="{'readonly': [('commission_free', '=', True)]}"/>
                 </field>
             </field>
         </record>
 
-        <record id="invoice_form_agent" model="ir.ui.view">
-            <field name="name">account.invoice.form.agent</field>
+        <record id="invoice_form_commission" model="ir.ui.view">
+            <field name="name">account.invoice.form.commission</field>
             <field name="model">account.invoice</field>
             <field name="inherit_id" ref="account.invoice_form" />
             <field name="arch" type="xml">
@@ -36,7 +36,7 @@
                 </field>
                 <xpath expr="//field[@name='invoice_line']/tree//field[@name='price_subtotal']" position="after">
                     <field name="commission_free"/>
-                    <field name="agents"
+                    <field name="commissions"
                            attrs="{'readonly': [('commission_free', '=', True)]}"/>
                 </xpath>
                 <field name="amount_total" position="after">

--- a/sale_commission/views/account_invoice_view.xml
+++ b/sale_commission/views/account_invoice_view.xml
@@ -19,10 +19,19 @@
             <field name="inherit_id" ref="account.view_invoice_line_form" />
             <field name="arch" type="xml">
                 <field name="company_id" position="after">
-                    <field name="commission_free"/>
-                    <field name="commissions"
-                           attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                  <field name="commission_free"/>
                 </field>
+                <xpath expr="//label[@for='name']" position="before">
+                  <group string="Commissions" colspan="4" attrs="{'invisible': [('commission_free', '=', True)]}">
+                    <field name="commissions" nolabel="1">
+                      <tree string="Commissions">
+                        <field name="agent" />
+                        <field name="commission" />
+                        <field name="amount" />
+                      </tree>
+                    </field>
+                  </group>
+                </xpath>
             </field>
         </record>
 
@@ -36,8 +45,7 @@
                 </field>
                 <xpath expr="//field[@name='invoice_line']/tree//field[@name='price_subtotal']" position="after">
                     <field name="commission_free"/>
-                    <field name="commissions"
-                           attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                    <field name="commissions" invisible="1" />
                 </xpath>
                 <field name="amount_total" position="after">
                     <field name="commission_total"

--- a/sale_commission/views/res_partner_view.xml
+++ b/sale_commission/views/res_partner_view.xml
@@ -23,12 +23,23 @@
                         <group>
                             <group>
                                 <field name="agent_type"/>
-                                <field name="commission"
-                                       attrs="{'required': [('agent', '=', True)]}"/>
                             </group>
                             <group>
                                 <field name="settlement"/>
                             </group>
+                            <group string="Commissions" colspan="4">
+                                <field name="commissions" nolabel="1">
+                                    <tree string="Commissions">
+                                        <field name="name" />
+                                        <field name="period" />
+                                        <field name="commission_type" />
+                                        <field name="fix_qty" />
+                                        <field name="sections" />
+                                        <field name="scope" />
+                                    </tree>
+                                </field>
+                            </group>
+
                             <group colspan="4"
                                    string="Settlements">
                                 <field name="settlements" nolabel="1">

--- a/sale_commission/views/sale_commission_view.xml
+++ b/sale_commission/views/sale_commission_view.xml
@@ -25,6 +25,8 @@
                         </group>
                         <group>
                             <field name="commission_type" />
+                            <field name="period" />
+                            <field name="scope" />
                         </group>
                     </group>
                     <group string="Rates definition" colspan="4">

--- a/sale_commission/views/sale_order_view.xml
+++ b/sale_commission/views/sale_order_view.xml
@@ -12,12 +12,12 @@
                 </field>
                 <xpath expr="//field[@name='order_line']/tree//field[@name='price_subtotal']" position="after">
                     <field name="commission_free"/>
-                    <field name="agents"
+                    <field name="commissions"
                            attrs="{'readonly': [('commission_free', '=', True)]}"/>
                 </xpath>
                 <xpath expr="//field[@name='order_line']/form//field[@name='address_allotment_id']" position="after">
                     <field name="commission_free"/>
-                    <field name="agents"
+                    <field name="commissions"
                            attrs="{'readonly': [('commission_free', '=', True)]}"/>
                 </xpath>
                 <field name="amount_total" position="after">
@@ -29,8 +29,8 @@
         </record>
 
         <record model="ir.ui.view" id="view_sale_order_line_tree">
-            <field name="name">sale.order.line.agent.tree</field>
-            <field name="model">sale.order.line.agent</field>
+            <field name="name">sale.order.line.commission.tree</field>
+            <field name="model">sale.order.line.commission</field>
             <field name="arch" type="xml">
                 <tree string="Agents" editable="bottom">
                     <field name="agent"/>

--- a/sale_commission/views/sale_order_view.xml
+++ b/sale_commission/views/sale_order_view.xml
@@ -12,13 +12,11 @@
                 </field>
                 <xpath expr="//field[@name='order_line']/tree//field[@name='price_subtotal']" position="after">
                     <field name="commission_free"/>
-                    <field name="commissions"
-                           attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                    <field name="commissions" invisible="1" />
                 </xpath>
                 <xpath expr="//field[@name='order_line']/form//field[@name='address_allotment_id']" position="after">
                     <field name="commission_free"/>
-                    <field name="commissions"
-                           attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                    <field name="commissions" invisible="1" />
                 </xpath>
                 <field name="amount_total" position="after">
                     <field name="commission_total"
@@ -32,9 +30,10 @@
             <field name="name">sale.order.line.commission.tree</field>
             <field name="model">sale.order.line.commission</field>
             <field name="arch" type="xml">
-                <tree string="Agents" editable="bottom">
-                    <field name="agent"/>
-                    <field name="commission"/>
+                <tree string="Commissions" editable="bottom">
+                    <field name="agent" />
+                    <field name="commission" />
+                    <field name="amount" />
                 </tree>
             </field>
         </record>

--- a/sale_commission/views/settlement_view.xml
+++ b/sale_commission/views/settlement_view.xml
@@ -69,11 +69,11 @@
                     <group string="Commission lines" colspan="4">
                         <field name="lines" nolabel="1">
                             <tree string="Settlement lines">
-                                <field name="date"/>
+                                <field name="invoice_date"/>
                                 <field name="invoice"/>
                                 <field name="invoice_line"/>
                                 <field name="commission"/>
-                                <field name="settled_amount"/>
+                                <field name="amount"/>
                             </tree>
                         </field>
                     </group>

--- a/sale_commission/views/settlement_view.xml
+++ b/sale_commission/views/settlement_view.xml
@@ -97,7 +97,8 @@
                     <field name="invoice"/>
                     <field name="invoice_line"/>
                     <field name="commission"/>
-                    <field name="settled_amount" sum="Settled total"/>
+                    <field name="settlement_state" />
+                    <field name="settled_amount" sum="Total"/>
                 </tree>
             </field>
         </record>
@@ -135,7 +136,7 @@
         </record>
 
         <record model="ir.actions.act_window" id="action_settlement_report">
-            <field name="name">Agents settlements analysis</field>
+            <field name="name">Commission Analysis</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">sale.commission.settlement.line</field>
             <field name="view_type">form</field>

--- a/sale_commission/wizard/wizard_settle.py
+++ b/sale_commission/wizard/wizard_settle.py
@@ -26,6 +26,7 @@ from dateutil.relativedelta import relativedelta
 
 from ..models import sale_commission as sc
 
+
 class SaleCommissionMakeSettle(models.TransientModel):
     _name = "sale.commission.make.settle"
 
@@ -74,13 +75,11 @@ class SaleCommissionMakeSettle(models.TransientModel):
         else:
             raise exceptions.Warning(_("Settlement period not valid."))
 
-
     @api.multi
     def action_settle(self):
         self.ensure_one()
         commission_line_obj = self.env['account.invoice.line.commission']
         settlement_obj = self.env['sale.commission.settlement']
-        settlement_line_obj = self.env['sale.commission.settlement.line']
         if not self.agents:
             self.agents = self.env['res.partner'].search(
                 [('agent', '=', True)])


### PR DESCRIPTION
Offer support for commissions on first sale only per customer. 
Will add a boolean check to sale.commission model. Commission amount will evaluate to zero if the commission type is applicable for first purchase only and the customer has purchased before
