### PR TITLE
[FIX] Fix singleton error

### DIFF
--- a/sale_commission/models/account_invoice.py
+++ b/sale_commission/models/account_invoice.py
@@ -131,7 +131,7 @@ class AccountInvoiceLineAgent(models.Model):
         # Count lines of not open or paid invoices as settled for not
         # being included in settlements
         for line in self:
-            self.settled = (line.invoice.state not in ('open', 'paid') or
+            line.settled = (line.invoice.state not in ('open', 'paid') or
                             any(x.settlement.state != 'cancel'
                                 for x in line.agent_line))
 


### PR DESCRIPTION
I had this Problem:
-i create a SO with 2 lines; every lines has no product and 1 agent
-i validate the sale order and create the invoice
-try to validate invoice and system return ValueError Expected singleton: account.invoice.line.agent(

I create this PR in order to resolve this Problem
