### PR TITLE
[8.0][sale_commission] Change visibility of agents field to only show when partner is a customer.

### DIFF
--- a/sale_commission/__openerp__.py
+++ b/sale_commission/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Sales commissions',
-    'version': '8.0.2.0.0',
+    'version': '8.0.2.1.0',
     'author': 'Pexego, '
               'Savoire-faire linux, '
               'Avanzosc, '

--- a/sale_commission/views/res_partner_view.xml
+++ b/sale_commission/views/res_partner_view.xml
@@ -13,7 +13,7 @@
                 </xpath>
                 <field name="user_id" position="after">
                     <field name="agents"
-                           attrs="{'invisible': [('agent', '=', True)]}"
+                           attrs="{'invisible': [('customer', '=', False)]}"
                            widget="many2many_tags"/>
                 </field>
                 <page name="sales_purchases" position="after">


### PR DESCRIPTION
(instead of showing when agent is not an agent)

In our company, an agent might also be a customer.

We think it makes more sense this way.

Comments?
