### PR TITLE
[FIX] sale_commission: Don't put supplier flag if not agent

### DIFF
--- a/sale_commission/__openerp__.py
+++ b/sale_commission/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Sales commissions',
-    'version': '8.0.2.1.0',
+    'version': '8.0.2.1.1',
     'author': 'Pexego, '
               'Savoire-faire linux, '
               'Avanzosc, '

--- a/sale_commission/models/res_partner.py
+++ b/sale_commission/models/res_partner.py
@@ -39,5 +39,5 @@ class ResPartner(models.Model):
 
     @api.onchange('agent_type')
     def onchange_agent_type(self):
-        if self.agent_type == 'agent':
+        if self.agent_type == 'agent' and self.agent:
             self.supplier = True


### PR DESCRIPTION
Without this condition, all partners are suppliers, because the default
value for agent_type is agent and the onchange is executed.
