### PR TITLE
[FIX][8.0][sale_commission] Fixes #61 and #63.

### DIFF
--- a/sale_commission/__openerp__.py
+++ b/sale_commission/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Sales commissions',
-    'version': '8.0.2.2.2',
+    'version': '8.0.2.3.0',
     'author': 'Pexego, '
               'Savoire-faire linux, '
               'Avanzosc, '

--- a/sale_commission/models/account_invoice.py
+++ b/sale_commission/models/account_invoice.py
@@ -86,27 +86,37 @@ class AccountInvoiceLineAgent(models.Model):
     _name = "account.invoice.line.agent"
 
     invoice_line = fields.Many2one(
-        comodel_name="account.invoice.line", required=True, ondelete="cascade")
+        comodel_name="account.invoice.line",
+        ondelete="cascade",
+        required=True, copy=False)
     invoice = fields.Many2one(
-        comodel_name="account.invoice", string="Invoice",
-        related="invoice_line.invoice_id", store=True)
+        string="Invoice", comodel_name="account.invoice",
+        related="invoice_line.invoice_id",
+        store=True)
     invoice_date = fields.Date(
-        string="Invoice date", related="invoice.date_invoice", store=True,
-        readonly=True)
+        string="Invoice date",
+        related="invoice.date_invoice",
+        store=True, readonly=True)
     product = fields.Many2one(
-        comodel_name='product.product', related="invoice_line.product_id")
+        comodel_name='product.product',
+        related="invoice_line.product_id")
     agent = fields.Many2one(
-        comodel_name="res.partner", required=True, ondelete="restrict",
-        domain="[('agent', '=', True)]")
+        comodel_name="res.partner",
+        domain="[('agent', '=', True)]",
+        ondelete="restrict",
+        required=True)
     commission = fields.Many2one(
-        comodel_name="sale.commission", required=True, ondelete="restrict")
+        comodel_name="sale.commission", ondelete="restrict", required=True)
     amount = fields.Float(
         string="Amount settled", compute="_compute_amount", store=True)
     agent_line = fields.Many2many(
         comodel_name='sale.commission.settlement.line',
-        relation='settlement_agent_line_rel', column1='agent_line_id',
-        column2='settlement_id')
-    settled = fields.Boolean(compute="_compute_settled", store=True)
+        relation='settlement_agent_line_rel',
+        column1='agent_line_id', column2='settlement_id',
+        copy=False)
+    settled = fields.Boolean(
+        compute="_compute_settled",
+        store=True, copy=False)
 
     @api.onchange('agent')
     def onchange_agent(self):

--- a/sale_commission/views/account_invoice_view.xml
+++ b/sale_commission/views/account_invoice_view.xml
@@ -6,7 +6,8 @@
             <field name="model">account.invoice.line.agent</field>
             <field name="arch" type="xml">
                 <tree string="Invoice line agents and commissions" editable="bottom">
-                    <field name="agent" />
+                    <field name="agent" 
+                        context="{'default_agent': True, 'default_customer': False, 'default_supplier': True}" />
                     <field name="commission" />
                     <field name="amount" />
                 </tree>


### PR DESCRIPTION
Fixes #61 and #63.

Also I've reordered field definitions for readability.

Even though it wasn't needed to fix the bugs, I've added `Copy=False` in `invoice_line` field. I'm guessing it was being copied and then replaced, so it was ok. But I think it's better -- safer -- if it's not copied in the first place.
