### PR TITLE
[WIP][8.0][sale_commission] Add security group 'Commissions in Sale Order Lines'

### DIFF
--- a/sale_commission/__openerp__.py
+++ b/sale_commission/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Sales commissions',
-    'version': '8.0.2.3.0',
+    'version': '8.0.2.4.0',
     'author': 'Pexego, '
               'Savoire-faire linux, '
               'Avanzosc, '
@@ -34,6 +34,7 @@
     ],
     "data": [
         "security/ir.model.access.csv",
+        "security/sale_commission_security.xml",
         "views/product_template_view.xml",
         "views/res_partner_view.xml",
         "views/sale_commission_view.xml",

--- a/sale_commission/models/sale_order.py
+++ b/sale_commission/models/sale_order.py
@@ -39,9 +39,11 @@ class SaleOrderLine(models.Model):
     agents = fields.One2many(
         string="Agents & commissions",
         comodel_name='sale.order.line.agent', inverse_name='sale_line',
+        groups="sale_commission.group_commission_per_so_line",
         copy=True, readonly=True, default=_default_agents)
     commission_free = fields.Boolean(
         string="Comm. free", related="product_id.commission_free",
+        groups="sale_commission.group_commission_per_so_line",
         store=True, readonly=True)
 
     @api.model

--- a/sale_commission/security/sale_commission_security.xml
+++ b/sale_commission/security/sale_commission_security.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+        <record id="sale_commission.group_commission_per_so_line" model="res.groups">
+            <field name="name">Commissions in Sale Order Lines</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+            <field name="users" eval="[(4, ref('base.user_root'))]"/>
+            <field name="comment">Members of this group can view and edit Agents &amp; Commissions per Sale Order's and Invoice's Lines</field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Adds a security group to show/hide the agents & commissions in sale order lines and invoices.

This is related to: https://github.com/OCA/commission/issues/62, since I'm trying to avoid that error.
Also somewhat related to #49 & #25 & #52

And also inspired by this PR https://github.com/OCA/commission/pull/29, specifically this https://github.com/OCA/commission/pull/29#issuecomment-136230386 by @pedrobaeza  
