### PR TITLE
[FIX][8.0][sale_commission] https://github.com/OCA/commission/issues/76

### DIFF
--- a/sale_commission/__openerp__.py
+++ b/sale_commission/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Sales commissions',
-    'version': '8.0.2.3.0',
+    'version': '8.0.2.3.1',
     'author': 'Pexego, '
               'Savoire-faire linux, '
               'Avanzosc, '

--- a/sale_commission/models/account_invoice.py
+++ b/sale_commission/models/account_invoice.py
@@ -122,8 +122,7 @@ class AccountInvoiceLineAgent(models.Model):
     def onchange_agent(self):
         self.commission = self.agent.commission
 
-    @api.depends('commission.commission_type', 'invoice_line.price_subtotal',
-                 'commission.amount_base_type')
+    @api.depends('invoice_line.price_subtotal')
     def _compute_amount(self):
         for line in self:
             line.amount = 0.0

--- a/sale_commission/models/sale_order.py
+++ b/sale_commission/models/sale_order.py
@@ -76,8 +76,7 @@ class SaleOrderLineAgent(models.Model):
     def onchange_agent(self):
         self.commission = self.agent.commission
 
-    @api.depends('commission.commission_type', 'sale_line.price_subtotal',
-                 'commission.amount_base_type')
+    @api.depends('sale_line.price_subtotal')
     def _compute_amount(self):
         for line in self:
             line.amount = 0.0


### PR DESCRIPTION
https://github.com/OCA/commission/issues/76

This partially fixes the bug.

It no longer recalculates agent lines when updating a commission rule.

But, the following known issues remain:
1. It will still recalculate agent lines when making the settlement. It seems related fields trigger recomputation of fields. But, at least, it will **not** trigger updates on already created settlements.
2. When making an invoice from a sale order, it will recalculate the agent line (since it's actually a new one) If the commission rule has been updated after the sales order but before the invoice, the new rule will apply. (I don't believe this is expected, so it should be warned)

Given **1.** ; **2.** is irrelevant.. but still, I thought it should be mentioned.
