### PR TITLE
Commission partner

### DIFF
--- a/sale_commission_partner/README.rst
+++ b/sale_commission_partner/README.rst
@@ -1,0 +1,38 @@
+Commission partner details
+===========================
+
+This module adds the partner field to sale_commision information to keep track
+of the partner related to each commissioned invoice, trying to adapt to an
+usual requirement from commission agents.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/commission/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/commission/issues/new?body=module:%20sale_stock_commission%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+* Rubén Cabrera <rcabrera@bisnesmart.com>
+
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/sale_commission_partner/README.rst
+++ b/sale_commission_partner/README.rst
@@ -5,6 +5,10 @@ This module adds the partner field to sale_commision information to keep track
 of the partner related to each commissioned invoice, trying to adapt to an
 usual requirement from commission agents.
 
+It also adds the related field "subtotal", which points to the amount of the
+corresponding invoice line, also useful when it comes to discuss agent's
+invoices. 
+
 Bug Tracker
 ===========
 

--- a/sale_commission_partner/__init__.py
+++ b/sale_commission_partner/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#       bisneSmart
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import models

--- a/sale_commission_partner/__openerp__.py
+++ b/sale_commission_partner/__openerp__.py
@@ -1,0 +1,38 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) bisneSmart
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+{
+    'name': 'Sale commission partner',
+    'version': '8.0.1.0.0',
+    'author': 'bisneSmart',
+    "category": "Generic Modules/Sales & Purchases",
+    'license': 'AGPL-3',
+    'depends': [
+        'sale_commission',
+    ],
+    'contributors': [
+        "Rubén Cabrera <rcabrera@bisnesmart.com>",
+    ],
+    "data": [
+        "views/settlement_view.xml",
+    ],
+    "installable": True,
+    "auto_install": True,
+}

--- a/sale_commission_partner/i18n/es.po
+++ b/sale_commission_partner/i18n/es.po
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_commission_partner
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Community Association\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-06-26 19:44+0000\n"
+"PO-Revision-Date: 2016-06-26 21:48+0100\n"
+"Last-Translator: Rubén Cabrera <rcabrera@bisnesmart.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.5.4\n"
+"Language: es_ES\n"
+
+#. module: sale_commission_partner
+#: field:sale.commission.settlement.line,partner_id:0
+msgid "Partner"
+msgstr "Empresa"

--- a/sale_commission_partner/i18n/es.po
+++ b/sale_commission_partner/i18n/es.po
@@ -6,15 +6,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Community Association\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-26 19:44+0000\n"
-"PO-Revision-Date: 2016-06-26 21:48+0100\n"
+"POT-Creation-Date: 2016-06-26 20:16+0000\n"
+"PO-Revision-Date: 2016-06-26 22:18+0100\n"
 "Last-Translator: Rubén Cabrera <rcabrera@bisnesmart.com>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.5.4\n"
 "Language: es_ES\n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: sale_commission_partner
+#: field:sale.commission.settlement.line,subtotal:0
+msgid "Amount"
+msgstr "Base"
 
 #. module: sale_commission_partner
 #: field:sale.commission.settlement.line,partner_id:0

--- a/sale_commission_partner/models/__init__.py
+++ b/sale_commission_partner/models/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    bisneSmart
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import settlement

--- a/sale_commission_partner/models/settlement.py
+++ b/sale_commission_partner/models/settlement.py
@@ -23,7 +23,7 @@
 from openerp import api, exceptions, fields, models, _
 
 
-class Settlement(models.Model):
+class SettlementLine(models.Model):
     _name = "sale.commission.settlement.line"
     _inherit = "sale.commission.settlement.line"
 
@@ -32,3 +32,8 @@ class Settlement(models.Model):
                                 related='invoice.partner_id',
                                 store=True,
                                 )
+    subtotal = fields.Float(
+                            comodel_name='account.invoice.line',
+                            related='invoice_line.price_subtotal',
+                            store=True,
+                            )

--- a/sale_commission_partner/models/settlement.py
+++ b/sale_commission_partner/models/settlement.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#   Copyright (C) 2016 bisneSmart
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+from openerp import api, exceptions, fields, models, _
+
+
+class Settlement(models.Model):
+    _name = "sale.commission.settlement.line"
+    _inherit = "sale.commission.settlement.line"
+
+    partner_id = fields.Many2one(
+                                comodel_name="res.partner",
+                                related='invoice.partner_id',
+                                store=True,
+                                )

--- a/sale_commission_partner/views/settlement_view.xml
+++ b/sale_commission_partner/views/settlement_view.xml
@@ -9,6 +9,10 @@
             <field name="date" position="after">
               <field name="partner_id" />
             </field>
+            <field name="invoice_line" position="after">
+              <field name="subtotal" />
+            </field>
+
           </field>
       </record>
 
@@ -19,6 +23,7 @@
           <field name="arch" type="xml">
             <field name="date" position="after">
               <field name="partner_id" />
+              <field name="subtotal" />
             </field>
           </field>
       </record>
@@ -29,6 +34,9 @@
           <field name="arch" type="xml">
             <field name="date" position="after">
               <field name="partner_id" />
+            </field>
+            <field name="invoice_line" position="after">
+              <field name="subtotal" />
             </field>
           </field>
       </record>

--- a/sale_commission_partner/views/settlement_view.xml
+++ b/sale_commission_partner/views/settlement_view.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+      <record id="sale_commission_partner_view" model="ir.ui.view">
+          <field name="name">sale.commission.line.partner</field>
+          <field name="model">sale.commission.settlement.line</field>
+          <field name="inherit_id" ref="sale_commission.view_settlement_line_tree"></field>
+          <field name="arch" type="xml">
+            <field name="date" position="after">
+              <field name="partner_id" />
+            </field>
+          </field>
+      </record>
+
+      <record id="sale_commission_partner_search_view" model="ir.ui.view">
+          <field name="name">sale.commission.line.search_partner</field>
+          <field name="model">sale.commission.settlement.line</field>
+          <field name="inherit_id" ref="sale_commission.view_settlement_line_search"></field>
+          <field name="arch" type="xml">
+            <field name="date" position="after">
+              <field name="partner_id" />
+            </field>
+          </field>
+      </record>
+      <record id="sale_commission_form_partner" model="ir.ui.view">
+          <field name="name">sale.commission.form.partner</field>
+          <field name="model">sale.commission.settlement</field>
+          <field name="inherit_id" ref="sale_commission.view_settlement_form"></field>
+          <field name="arch" type="xml">
+            <field name="date" position="after">
+              <field name="partner_id" />
+            </field>
+          </field>
+      </record>
+
+<record id="sale_commission_search_partner" model="ir.ui.view">
+    <field name="name">sale.commission.line.graph</field>
+    <field name="model">sale.commission.settlement.line</field>
+    <field name="inherit_id" ref="sale_commission.view_settlement_line_graph"></field>
+    <field name="arch" type="xml">
+      <field name="date" position="after">
+        <field name="partner_id" type="row" />
+      </field>
+    </field>
+</record>
+    </data>
+</openerp>


### PR DESCRIPTION
Adds the partner_id field so it can be displayed on commission lines information and used in report views (that's the only reason it's a stored field). 

After a while using sale_commission and sale_commission_stock, a couple of clients have gone mad trying to share commission information with agents, who usually work with just the partner sum of invoiced commissions. Also added the  "subtotal" field, related to the amount of the invoice line for the same reason. 
