### PR TITLE
[8.0][FIX] api decorator on module sale_commission

### DIFF
--- a/sale_commission/models/account_invoice.py
+++ b/sale_commission/models/account_invoice.py
@@ -39,7 +39,7 @@ class AccountInvoice(models.Model):
         settlements.write({'state': 'invoiced'})
         return super(AccountInvoice, self).invoice_validate()
 
-    @api.multi
+    @api.model
     def _refund_cleanup_lines(self, lines):
         """ugly function to map all fields of account.invoice.line
         when creates refund invoice"""


### PR DESCRIPTION
The method "_refund_cleanup_lines" in odoo is defined like "def _refund_cleanup_lines(self, lines)" and should be decoreted with @api.model instead of @api.multi