### PR TITLE
[FIX] sale_commission: installation fails if en_US language is not installed

### DIFF
--- a/sale_commission/__manifest__.py
+++ b/sale_commission/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Sales commissions',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     'author': 'Odoo Community Association (OCA)',
     'category': 'Sales Management',
     'license': 'AGPL-3',

--- a/sale_commission/demo/sale_agent_demo.xml
+++ b/sale_commission/demo/sale_agent_demo.xml
@@ -23,7 +23,6 @@
         <field name="street">56 Beijing street</field>
         <field name="agent" eval="1" />
         <field name="commission" ref="demo_commission_paid" />
-        <field name="lang">en_US</field>
     </record>
 
     <record id="res_partner_eiffel_sale_agent" model="res.partner">
@@ -35,7 +34,6 @@
         <field name="street">Wall Street 2</field>
         <field name="agent" eval="1" />
         <field name="commission" ref="demo_commission" />
-        <field name="lang">en_US</field>
     </record>
 
     <record id="res_partner_tiny_sale_agent" model="res.partner">
@@ -47,7 +45,6 @@
         <field name="street">Belgium Gao</field>
         <field name="agent" eval="1" />
         <field name="commission" ref="demo_commission" />
-        <field name="lang">en_US</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
```
File "/opt/odoo/v11/core/odoo/fields.py", line 1806, in convert_to_cache
raise ValueError("Wrong value for %s: %r" % (self, value))
odoo.tools.convert.ParseError: "Wrong value for res.partner.lang: 'en_US'" while parsing /opt/odoo/v11/oca/commission/sale_commission/demo/sale_agent_demo.xml:17, near
<record id="res_partner_pritesh_sale_agent" model="res.partner">
<field name="name">Pritesh Sales Agent</field>
<field name="city">Ahmedabad</field>
<field name="zip">380007</field>
<field name="country_id" model="res.country" search="[('name','=','India')]"/>
<field name="street">56 Beijing street</field>
<field name="agent" eval="1"/>
<field name="commission" ref="demo_commission_paid"/>
<field name="lang">en_US</field>
</record>
```