### PR TITLE
[ADD] security on commission

### DIFF
--- a/sale_commission/views/res_partner_view.xml
+++ b/sale_commission/views/res_partner_view.xml
@@ -18,6 +18,7 @@
             <page name="sales_purchases" position="after">
                 <page name="agent_information"
                       string="Agent information"
+                      groups="sales_team.group_sale_manager"
                       attrs="{'invisible': [('agent', '=', False)]}">
                     <group>
                         <group>

--- a/sale_commission/views/sale_commission_view.xml
+++ b/sale_commission/views/sale_commission_view.xml
@@ -60,6 +60,7 @@
     <menuitem name="Commissions Management"
               id="menu_sale_commissions_management"
               parent="sale.sale_menu_root"
+              groups="sales_team.group_sale_manager"
               sequence="4"
     />
 


### PR DESCRIPTION
No security was added on commission, so if I had a user with no access to sales, it could see all settlement and conditions. 

I modified the menus so, only sale manager can access them.