### PR TITLE
[11.0][FIX] minor fixes

### DIFF
--- a/sale_commission/__manifest__.py
+++ b/sale_commission/__manifest__.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
-
 {
     'name': 'Sales commissions',
-    'version': '11.0.1.1.1',
+    'version': '11.0.1.2.1',
     'author': 'Odoo Community Association (OCA)',
     'category': 'Sales Management',
     'license': 'AGPL-3',

--- a/sale_commission/wizard/wizard_settle.py
+++ b/sale_commission/wizard/wizard_settle.py
@@ -93,7 +93,8 @@ class SaleCommissionMakeSettle(models.TransientModel):
                             ('agent', '=', agent.id),
                             ('date_from', '=', sett_from),
                             ('date_to', '=', sett_to),
-                            ('company_id', '=', company.id)
+                            ('company_id', '=', company.id),
+                            ('state', '=', 'settled')
                         ], limit=1)
                         if not settlement:
                             settlement = settlement_obj.create({

--- a/sale_commission_formula/__manifest__.py
+++ b/sale_commission_formula/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Sale Commission Formula',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     'category': 'Sale',
     'license': 'AGPL-3',
     'summary': 'Sale commissions computed by formulas',

--- a/sale_commission_formula/models/account_invoice.py
+++ b/sale_commission_formula/models/account_invoice.py
@@ -26,5 +26,8 @@ class AccountInvoiceLineAgent(models.Model):
                 results = line_obj._get_formula_input_dict()
                 safe_eval(formula, results, mode="exec", nocopy=True)
                 line_obj.amount += float(results['result'])
+                # Refunds commissions are negative
+                if line_obj.invoice.type in ('out_refund', 'in_refund'):
+                    line_obj.amount = -line_obj.amount
             else:
                 return super(AccountInvoiceLineAgent, self)._compute_amount()


### PR DESCRIPTION
This PR fixes:
- In sale_commission prevents the possibility of creating new invoices with commissions belonging to a settled group that has already been invoiced. As, in this case, the generated vendor bill for this group cannot be updated.
- In sale_commission_formula takes into account whether if the invoice has been refunded or not.

@jbeficent @etobella 