### PR TITLE
[FIX] sale_commission: Avoid erasing of invoice agents

### DIFF
--- a/sale_commission/README.rst
+++ b/sale_commission/README.rst
@@ -17,6 +17,10 @@ You can define which base amount is going to be taken into account: net amount
 
 Known issues / Roadmap
 ======================
+* If you add order lines with commissions, and after that, change partner,
+  fiscal position, delivery method, or custom fields that changes something on
+  the order lines, yet non-saved commission lines will be lost. This is due to
+  a big bug partially documented in https://github.com/odoo/odoo/issues/17618.
 * Make it totally multi-company aware.
 * Allow to calculate and pay in other currency different from company one.
 * Allow to group by agent when generating invoices.

--- a/sale_commission/__manifest__.py
+++ b/sale_commission/__manifest__.py
@@ -2,8 +2,11 @@
 
 {
     'name': 'Sales commissions',
-    'version': '10.0.1.1.0',
-    'author': 'Odoo Community Association (OCA)',
+    'version': '10.0.2.0.0',
+    'author': 'Odoo Community Association (OCA),'
+              'Tecnativa,'
+              'AvanzOSC,'
+              'Agile Business Group',
     'category': 'Sales Management',
     'license': 'AGPL-3',
     'depends': [

--- a/sale_commission/i18n/es.po
+++ b/sale_commission/i18n/es.po
@@ -19,6 +19,12 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: sale_commission
+#: code:addons/sale_commission/models/account_invoice.py:114
+#, python-format
+msgid "%s commission agents"
+msgstr "%s comisionistas"
+
+#. module: sale_commission
 #: model:ir.ui.view,arch_db:sale_commission.sale_commission_make_invoice_form
 msgid "(keep empty for invoicing all the settlements)"
 msgstr "(mantener vacío para facturar todas las liquidaciones)"
@@ -29,9 +35,15 @@ msgid "(keep empty for making the settlement of all agents)"
 msgstr "(mantener vacío para realizar la liquidación de todos los agentes)"
 
 #. module: sale_commission
+#: code:addons/sale_commission/models/account_invoice.py:112
+#, python-format
+msgid "1 commission agent"
+msgstr "1 comisionista"
+
+#. module: sale_commission
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_active
 msgid "Active"
-msgstr "Activa"
+msgstr "Activo"
 
 #. module: sale_commission
 #: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_agent_agent
@@ -133,13 +145,16 @@ msgid "Check this field if the partner is a creditor or an agent."
 msgstr "Marque esta casilla si la empresa es un agente."
 
 #. module: sale_commission
+#: code:addons/sale_commission/models/account_invoice.py:108
 #: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_commission_free
 #: model:ir.model.fields,field_description:sale_commission.field_sale_order_line_commission_free
+#, python-format
 msgid "Comm. free"
 msgstr "Sin comisión"
 
 #. module: sale_commission
 #: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_agent_commission
+#: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_commission_status
 #: model:ir.model.fields,field_description:sale_commission.field_res_partner_commission
 #: model:ir.model.fields,field_description:sale_commission.field_res_users_commission
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_section_commission
@@ -227,7 +242,7 @@ msgstr "Creado por"
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_settlement_line_create_date
 #: model:ir.model.fields,field_description:sale_commission.field_sale_order_line_agent_create_date
 msgid "Created on"
-msgstr "Creado en"
+msgstr "Creado el"
 
 #. module: sale_commission
 #: model:ir.model.fields,field_description:sale_commission.field_res_partner_agent
@@ -284,6 +299,7 @@ msgid "Formula"
 msgstr "Fórmula"
 
 #. module: sale_commission
+#: model:ir.model.fields,field_description:sale_commission.field_delivery_carrier_commission_free
 #: model:ir.model.fields,field_description:sale_commission.field_product_product_commission_free
 #: model:ir.model.fields,field_description:sale_commission.field_product_template_commission_free
 msgid "Free of commission"
@@ -348,7 +364,7 @@ msgstr "Basado en facturas"
 #. module: sale_commission
 #: model:ir.model,name:sale_commission.model_account_invoice_line
 msgid "Invoice Line"
-msgstr "Línea de factura"
+msgstr "Linea de factura"
 
 #. module: sale_commission
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_invoice_state
@@ -403,7 +419,7 @@ msgstr "Mantener vacío para usar la fecha actual"
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_settlement_line___last_update
 #: model:ir.model.fields,field_description:sale_commission.field_sale_order_line_agent___last_update
 msgid "Last Modified on"
-msgstr "Última modificación el"
+msgstr "Última modificación en"
 
 #. module: sale_commission
 #: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_agent_write_uid
@@ -427,7 +443,7 @@ msgstr "Última actualización por"
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_write_date
 #: model:ir.model.fields,field_description:sale_commission.field_sale_order_line_agent_write_date
 msgid "Last Updated on"
-msgstr "Última actualización en"
+msgstr "Última actualización el"
 
 #. module: sale_commission
 #: code:addons/sale_commission/models/settlement.py:60
@@ -463,6 +479,12 @@ msgid "Net Amount"
 msgstr "Importe neto"
 
 #. module: sale_commission
+#: code:addons/sale_commission/models/account_invoice.py:110
+#, python-format
+msgid "No commission agents"
+msgstr "Sin comisionistas"
+
+#. module: sale_commission
 #: model:ir.model,name:sale_commission.model_res_partner
 msgid "Partner"
 msgstr "Empresa"
@@ -491,7 +513,7 @@ msgstr "Producto"
 #. module: sale_commission
 #: model:ir.model,name:sale_commission.model_product_template
 msgid "Product Template"
-msgstr "Plantilla producto"
+msgstr "Plantilla de producto"
 
 #. module: sale_commission
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_make_invoice_product
@@ -637,12 +659,8 @@ msgstr "El límite inferior no puede ser mayor que el superior."
 #. module: sale_commission
 #: model:ir.model.fields,help:sale_commission.field_res_partner_commission
 #: model:ir.model.fields,help:sale_commission.field_res_users_commission
-msgid ""
-"This is the default commission used in the sales where this agent is "
-"assigned. It can be changed on each operation if needed."
-msgstr ""
-"Ésta es la comisión por defecto usada cuando se asigna un agente. Puede ser "
-"cambiada en cada operación si es necesario."
+msgid "This is the default commission used in the sales where this agent is assigned. It can be changed on each operation if needed."
+msgstr "Ésta es la comisión por defecto usada cuando se asigna un agente. Puede ser cambiada en cada operación si es necesario."
 
 #. module: sale_commission
 #: model:ir.ui.view,arch_db:sale_commission.view_settlement_line_search
@@ -694,7 +712,7 @@ msgstr "Cancelar"
 #. module: sale_commission
 #: model:ir.model,name:sale_commission.model_account_invoice_line_agent
 msgid "account.invoice.line.agent"
-msgstr ""
+msgstr "account.invoice.line.agent"
 
 #. module: sale_commission
 #: model:ir.ui.view,arch_db:sale_commission.sale_commission_make_invoice_form
@@ -705,24 +723,25 @@ msgstr "o"
 #. module: sale_commission
 #: model:ir.model,name:sale_commission.model_sale_commission_make_invoice
 msgid "sale.commission.make.invoice"
-msgstr ""
+msgstr "sale.commission.make.invoice"
 
 #. module: sale_commission
 #: model:ir.model,name:sale_commission.model_sale_commission_make_settle
 msgid "sale.commission.make.settle"
-msgstr ""
+msgstr "sale.commission.make.settle"
 
 #. module: sale_commission
 #: model:ir.model,name:sale_commission.model_sale_commission_settlement_line
 msgid "sale.commission.settlement.line"
-msgstr ""
+msgstr "sale.commission.settlement.line"
 
 #. module: sale_commission
 #: model:ir.model,name:sale_commission.model_sale_order_line_agent
 msgid "sale.order.line.agent"
-msgstr ""
+msgstr "sale.order.line.agent"
 
 #. module: sale_commission
 #: model:ir.ui.view,arch_db:sale_commission.sale_commission_form
 msgid "sections"
 msgstr "secciones"
+

--- a/sale_commission/i18n/es.po
+++ b/sale_commission/i18n/es.po
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: sale_commission
-#: code:addons/sale_commission/models/account_invoice.py:114
+#: code:addons/sale_commission/models/sale_commission_mixin.py:55
 #, python-format
 msgid "%s commission agents"
 msgstr "%s comisionistas"
@@ -35,7 +35,7 @@ msgid "(keep empty for making the settlement of all agents)"
 msgstr "(mantener vacío para realizar la liquidación de todos los agentes)"
 
 #. module: sale_commission
-#: code:addons/sale_commission/models/account_invoice.py:112
+#: code:addons/sale_commission/models/sale_commission_mixin.py:53
 #, python-format
 msgid "1 commission agent"
 msgstr "1 comisionista"
@@ -47,6 +47,7 @@ msgstr "Activo"
 
 #. module: sale_commission
 #: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_agent_agent
+#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_line_mixin_agent
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_settlement_agent
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_settlement_line_agent
 #: model:ir.model.fields,field_description:sale_commission.field_sale_order_line_agent_agent
@@ -86,12 +87,15 @@ msgstr "Agentes"
 
 #. module: sale_commission
 #: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_agents
+#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_mixin_agents
 #: model:ir.model.fields,field_description:sale_commission.field_sale_order_line_agents
 msgid "Agents & commissions"
 msgstr "Agentes y comisiones"
 
 #. module: sale_commission
 #: model:ir.model.fields,help:sale_commission.field_account_invoice_line_agents
+#: model:ir.model.fields,help:sale_commission.field_sale_commission_mixin_agents
+#: model:ir.model.fields,help:sale_commission.field_sale_order_line_agents
 msgid "Agents/Commissions related to the invoice line."
 msgstr "Agentes/Comisiones relacionadas con la línea de factura."
 
@@ -145,8 +149,9 @@ msgid "Check this field if the partner is a creditor or an agent."
 msgstr "Marque esta casilla si la empresa es un agente."
 
 #. module: sale_commission
-#: code:addons/sale_commission/models/account_invoice.py:108
+#: code:addons/sale_commission/models/sale_commission_mixin.py:49
 #: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_commission_free
+#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_mixin_commission_free
 #: model:ir.model.fields,field_description:sale_commission.field_sale_order_line_commission_free
 #, python-format
 msgid "Comm. free"
@@ -157,9 +162,12 @@ msgstr "Sin comisión"
 #: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_commission_status
 #: model:ir.model.fields,field_description:sale_commission.field_res_partner_commission
 #: model:ir.model.fields,field_description:sale_commission.field_res_users_commission
+#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_line_mixin_commission
+#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_mixin_commission_status
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_section_commission
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_settlement_line_commission
 #: model:ir.model.fields,field_description:sale_commission.field_sale_order_line_agent_commission
+#: model:ir.model.fields,field_description:sale_commission.field_sale_order_line_commission_status
 #: model:ir.ui.view,arch_db:sale_commission.sale_commission_form
 msgid "Commission"
 msgstr "Comisión"
@@ -273,8 +281,10 @@ msgstr "Mes"
 #. module: sale_commission
 #: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_agent_display_name
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_display_name
+#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_line_mixin_display_name
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_make_invoice_display_name
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_make_settle_display_name
+#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_mixin_display_name
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_section_display_name
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_settlement_display_name
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_settlement_line_display_name
@@ -340,8 +350,10 @@ msgstr "Agrupar por"
 #. module: sale_commission
 #: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_agent_id
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_id
+#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_line_mixin_id
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_make_invoice_id
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_make_settle_id
+#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_mixin_id
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_section_id
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_settlement_id
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_settlement_line_id
@@ -383,12 +395,6 @@ msgid "Invoice exception"
 msgstr "Excepción de factura"
 
 #. module: sale_commission
-#: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_agent_invoice_line
-#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_settlement_line_invoice_line
-msgid "Invoice line"
-msgstr "Línea de factura"
-
-#. module: sale_commission
 #: model:ir.ui.view,arch_db:sale_commission.invoice_line_agent_tree
 msgid "Invoice line agents and commissions"
 msgstr "Agentes y comisiones de línea de factura"
@@ -412,8 +418,10 @@ msgstr "Mantener vacío para usar la fecha actual"
 #. module: sale_commission
 #: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_agent___last_update
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission___last_update
+#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_line_mixin___last_update
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_make_invoice___last_update
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_make_settle___last_update
+#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_mixin___last_update
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_section___last_update
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_settlement___last_update
 #: model:ir.model.fields,field_description:sale_commission.field_sale_commission_settlement_line___last_update
@@ -463,6 +471,16 @@ msgid "Make settlements"
 msgstr "Realizar liquidaciones"
 
 #. module: sale_commission
+#: model:ir.model,name:sale_commission.model_sale_commission_mixin
+msgid "Mixin model for applying to any object that wants to handle commissions"
+msgstr "Modelo mixin para aplicar a cualquier objeto que quiera manejar comisiones"
+
+#. module: sale_commission
+#: model:ir.model,name:sale_commission.model_sale_commission_line_mixin
+msgid "Mixin model for having commission agent lines in any object inheriting from this one"
+msgstr "Modelo mixin para tener líneas de agente de comisión en cualquier objeto heredando de éste"
+
+#. module: sale_commission
 #: selection:res.partner,settlement:0
 msgid "Monthly"
 msgstr "Mensual"
@@ -479,10 +497,18 @@ msgid "Net Amount"
 msgstr "Importe neto"
 
 #. module: sale_commission
-#: code:addons/sale_commission/models/account_invoice.py:110
+#: code:addons/sale_commission/models/sale_commission_mixin.py:51
 #, python-format
 msgid "No commission agents"
 msgstr "Sin comisionistas"
+
+#. module: sale_commission
+#: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_agent_object_id
+#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_line_mixin_object_id
+#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_settlement_line_invoice_line
+#: model:ir.model.fields,field_description:sale_commission.field_sale_order_line_agent_object_id
+msgid "Parent"
+msgstr "Padre"
 
 #. module: sale_commission
 #: model:ir.model,name:sale_commission.model_res_partner
@@ -507,6 +533,7 @@ msgstr "Periodo: de %s a %s"
 
 #. module: sale_commission
 #: model:ir.model.fields,field_description:sale_commission.field_account_invoice_line_agent_product
+#: model:ir.model.fields,field_description:sale_commission.field_sale_commission_mixin_product_id
 msgid "Product"
 msgstr "Producto"
 
@@ -535,11 +562,6 @@ msgstr "Definición de porcentajes"
 #: model:ir.ui.view,arch_db:sale_commission.view_order_agent_form_inherit
 msgid "Recompute lines agents"
 msgstr "Recalcular agentes de lineas"
-
-#. module: sale_commission
-#: model:ir.model.fields,field_description:sale_commission.field_sale_order_line_agent_sale_line
-msgid "Sale line"
-msgstr "Línea de venta"
 
 #. module: sale_commission
 #: model:ir.model,name:sale_commission.model_sale_order
@@ -636,13 +658,9 @@ msgstr "Buscar liquidaciones"
 #: model:ir.ui.view,arch_db:sale_commission.sale_commission_make_invoice_form
 #: model:ir.ui.view,arch_db:sale_commission.view_partner_form_agent
 #: model:ir.ui.view,arch_db:sale_commission.view_settlement_tree
-msgid "Settlements"
-msgstr "Liquidaciones"
-
-#. module: sale_commission
 #: model:ir.actions.act_window,name:sale_commission.action_settle_commission
 #: model:ir.ui.menu,name:sale_commission.menu_sattle_commissions
-msgid "Settlments"
+msgid "Settlements"
 msgstr "Liquidaciones"
 
 #. module: sale_commission
@@ -694,6 +712,7 @@ msgstr "Hasta"
 
 #. module: sale_commission
 #: sql_constraint:account.invoice.line.agent:0
+#: sql_constraint:sale.commission.line.mixin:0
 #: sql_constraint:sale.order.line.agent:0
 msgid "You can only add one time each agent."
 msgstr "Sólo puede añadir una vez cada agente."

--- a/sale_commission/models/__init__.py
+++ b/sale_commission/models/__init__.py
@@ -2,6 +2,7 @@
 
 from . import product_template
 from . import sale_commission
+from . import sale_commission_mixin
 from . import res_partner
 from . import sale_order
 from . import account_invoice

--- a/sale_commission/models/sale_commission_mixin.py
+++ b/sale_commission/models/sale_commission_mixin.py
@@ -72,6 +72,21 @@ class SaleCommissionMixin(models.AbstractModel):
             vals['agents'] = new_commands
         return super(SaleCommissionMixin, self).write(vals)
 
+    def _prepare_agents_vals(self):
+        """Hook method for preparing the values of agents.
+
+        :param: self: Record of the object that is being handled.
+        """
+        return []
+
+    def recompute_agents(self):
+        """Force a recomputation of the agents according prepare method."""
+        for record in self:
+            record.agents.unlink()
+            record.agents = [
+                (0, 0, vals) for vals in record._prepare_agents_vals()
+            ]
+
 
 class SaleCommissionLineMixin(models.AbstractModel):
     _name = "sale.commission.line.mixin"

--- a/sale_commission/models/sale_commission_mixin.py
+++ b/sale_commission/models/sale_commission_mixin.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+
+
+class SaleCommissionMixin(models.AbstractModel):
+    _name = 'sale.commission.mixin'
+    _description = "Mixin model for applying to any object that wants to " \
+                   "handle commissions"
+
+    @api.model
+    def _default_agents(self):
+        agents = []
+        if self.env.context.get('partner_id'):
+            partner = self.env['res.partner'].browse(
+                self.env.context['partner_id'])
+            for agent in partner.agents:
+                agents.append({'agent': agent.id,
+                               'commission': agent.commission.id})
+        return [(0, 0, x) for x in agents]
+
+    agents = fields.One2many(
+        comodel_name="sale.commission.line.mixin",
+        inverse_name="object_id",
+        string="Agents & commissions",
+        help="Agents/Commissions related to the invoice line.",
+        default=_default_agents,
+        copy=True,
+    )
+    product_id = fields.Many2one(
+        comodel_name="product.product",
+        string="Product",
+    )
+    commission_free = fields.Boolean(
+        string="Comm. free",
+        related="product_id.commission_free",
+        store=True,
+        readonly=True,
+    )
+    commission_status = fields.Char(
+        compute="_compute_commission_status",
+        string="Commission",
+    )
+
+    def _compute_commission_status(self):
+        for line in self:
+            if line.commission_free:
+                line.commission_status = _("Comm. free")
+            elif len(line.agents) == 0:
+                line.commission_status = _("No commission agents")
+            elif len(line.agents) == 1:
+                line.commission_status = _("1 commission agent")
+            else:
+                line.commission_status = _(
+                    "%s commission agents"
+                ) % len(line.agents)
+
+    def write(self, vals):
+        """Workaround for https://github.com/odoo/odoo/issues/17618."""
+        if 'agents' in vals:
+            new_commands = []
+            for i, command in enumerate(vals['agents']):
+                if i == 0 and command[0] == 5 and len(vals['agents']) > 1:
+                    # Remove initial [5] command for avoiding integrity error
+                    continue
+                if command[0] == 0 and not command[2]:
+                    # Remove empty add records
+                    continue
+                new_commands.append(command)
+            vals['agents'] = new_commands
+        return super(SaleCommissionMixin, self).write(vals)
+
+
+class SaleCommissionLineMixin(models.AbstractModel):
+    _name = "sale.commission.line.mixin"
+    _description = "Mixin model for having commission agent lines in " \
+                   "any object inheriting from this one"
+
+    object_id = fields.Many2one(
+        comodel_name="sale.commission.mixin",
+        ondelete="cascade",
+        required=True,
+        copy=False,
+        string="Parent",
+    )
+    agent = fields.Many2one(
+        comodel_name="res.partner",
+        domain="[('agent', '=', True)]",
+        ondelete="restrict",
+        required=True,
+    )
+    commission = fields.Many2one(
+        comodel_name="sale.commission",
+        ondelete="restrict",
+        required=True,
+    )
+
+    @api.onchange('agent')
+    def onchange_agent(self):
+        self.commission = self.agent.commission
+
+    _sql_constraints = [
+        ('unique_agent', 'UNIQUE(object_id, agent)',
+         'You can only add one time each agent.')
+    ]

--- a/sale_commission/models/settlement.py
+++ b/sale_commission/models/settlement.py
@@ -140,16 +140,22 @@ class SettlementLine(models.Model):
     _name = "sale.commission.settlement.line"
 
     settlement = fields.Many2one(
-        "sale.commission.settlement", readonly=True, ondelete="cascade",
-        required=True)
+        "sale.commission.settlement",
+        readonly=True,
+        ondelete="cascade",
+        required=True,
+    )
     agent_line = fields.Many2many(
         comodel_name='account.invoice.line.agent',
-        relation='settlement_agent_line_rel', column1='settlement_id',
-        column2='agent_line_id', required=True)
+        relation='settlement_agent_line_rel',
+        column1='settlement_id',
+        column2='agent_line_id',
+        required=True,
+    )
     date = fields.Date(related="agent_line.invoice_date", store=True)
     invoice_line = fields.Many2one(
         comodel_name='account.invoice.line', store=True,
-        related='agent_line.invoice_line')
+        related='agent_line.object_id')
     invoice = fields.Many2one(
         comodel_name='account.invoice', store=True, string="Invoice",
         related='invoice_line.invoice_id')

--- a/sale_commission/views/account_invoice_view.xml
+++ b/sale_commission/views/account_invoice_view.xml
@@ -22,7 +22,7 @@
             <field name="company_id" position="after">
                 <field name="commission_free"/>
                 <field name="agents"
-                       attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                       attrs="{'invisible': [('commission_free', '=', True)]}"/>
             </field>
         </field>
     </record>
@@ -36,15 +36,18 @@
                 <attribute name="context">{'partner_id': partner_id}</attribute>
             </field>
             <xpath expr="//field[@name='invoice_line_ids']/tree//field[@name='price_subtotal']" position="after">
-                <field name="commission_free"/>
-                <field name="agents"
-                       attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                <!-- Due to the issue https://github.com/odoo/odoo/issues/17618,
+                     we can't add agents field to this view, but using this
+                     computed field with the same information purposes makes
+                     the same work or event better, as we can include more info.
+                 -->
+                <field name="commission_status"/>
             </xpath>
             <xpath expr="//field[@name='invoice_line_ids']/tree" position="attributes">
                     <attribute name="editable"/>
             </xpath>
             <xpath expr="//field[@name='invoice_line_ids']" position="after">
-                <button name="recompute_lines_agents" type="object" string="Recompute lines agents" states="draft"></button>
+                <button name="recompute_lines_agents" type="object" string="Recompute lines agents" states="draft"/>
             </xpath>
             <field name="amount_total" position="after">
                 <field name="commission_total"

--- a/sale_commission/views/sale_order_view.xml
+++ b/sale_commission/views/sale_order_view.xml
@@ -13,14 +13,12 @@
                 <attribute name="editable"/>
             </xpath>
             <xpath expr="//field[@name='order_line']/tree//field[@name='price_subtotal']" position="after">
-                <field name="commission_free"/>
-                <field name="agents"
-                       attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                <field name="commission_status"/>
             </xpath>
             <xpath expr="//field[@name='order_line']/form//field[@name='customer_lead']/.." position="after">
                 <field name="commission_free"/>
                 <field name="agents"
-                       attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                       attrs="{'invisible': [('commission_free', '=', True)]}"/>
             </xpath>
             <field name="amount_total" position="after">
                 <field name="commission_total"
@@ -28,7 +26,7 @@
                        options="{'currency_field': 'currency_id'}"/>
             </field>
             <xpath expr="//field[@name='order_line']" position="after">
-                <button name="recompute_lines_agents" type="object" string="Recompute lines agents" states="draft"></button>
+                <button name="recompute_lines_agents" type="object" string="Recompute lines agents" states="draft"/>
             </xpath>
         </field>
     </record>

--- a/sale_commission/views/settlement_view.xml
+++ b/sale_commission/views/settlement_view.xml
@@ -133,14 +133,14 @@
     </record>
 
     <record model="ir.actions.act_window" id="action_settle_commission">
-        <field name="name">Settlments</field>
+        <field name="name">Settlements</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">sale.commission.settlement</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
     </record>
 
-    <menuitem name="Settlments"
+    <menuitem name="Settlements"
               id="menu_sattle_commissions"
               parent="menu_sale_commissions_management"
               action="action_settle_commission" />

--- a/sale_commission_formula/models/account_invoice.py
+++ b/sale_commission_formula/models/account_invoice.py
@@ -12,15 +12,13 @@ class AccountInvoiceLineAgent(models.Model):
 
     @api.model
     def _get_formula_input_dict(self):
-        return {'line': self.invoice_line,
+        return {'line': self.object_id,
                 'self': self}
 
-    @api.depends('commission.commission_type', 'invoice_line.price_subtotal',
-                 'commission.amount_base_type')
     def _compute_amount(self):
         for line_obj in self:
             if (line_obj.commission.commission_type == 'formula' and
-                not line_obj.invoice_line.product_id.commission_free and
+                not line_obj.object_id.product_id.commission_free and
                     line_obj.commission):
                 line_obj.amount = 0.0
                 formula = line_obj.commission.formula

--- a/sale_commission_formula/models/sale_order.py
+++ b/sale_commission_formula/models/sale_order.py
@@ -12,15 +12,13 @@ class SaleOrderLineAgent(models.Model):
 
     @api.model
     def _get_formula_input_dict(self):
-        return {'line': self.sale_line,
+        return {'line': self.object_id,
                 'self': self}
 
-    @api.depends('commission.commission_type', 'sale_line.price_subtotal',
-                 'commission.amount_base_type')
     def _compute_amount(self):
         for line_agent in self:
             if (line_agent.commission.commission_type == 'formula' and
-                not line_agent.sale_line.product_id.commission_free and
+                not line_agent.object_id.product_id.commission_free and
                     line_agent.commission):
                 line_agent.amount = 0.0
                 formula = line_agent.commission.formula


### PR DESCRIPTION
Some onchanges were introduced in hurrinico#2 for workarounding the issue odoo/odoo#17618, but they are causing that invoices that have been invoiced with the proper commissions propagated from sales order, to empty their values when changing one of the following values:

* Partner
* Journal
* Invoice date
* Payment term

It should be taking into account that there are a lot of extensions to this module that can put different agents according some conditions on sales order, but not on invoices (for example, *sale_commission_formula* with formula only in sales orders, or the new *sale_commission_pricelist*, that bases the commission on the pricelist item used, and that's only applicable on sales orders).

More over, the problem will still appear if you add in other module another onchange.

The solution to properly bypass the issue is to directly not add the field on the invoice form view. This way, there are no glitches. To compensate it, I have add it a computed field that show the same information, or even better, as we reduce the number of fields to 1 instead of 2, and this field can be used for expanding the given information.