### PR TITLE
[11.0][sale_commision]: temporary fix until https://github.com/odoo/odoo/issues/24702 is fixed

### DIFF
--- a/sale_commission/README.rst
+++ b/sale_commission/README.rst
@@ -20,7 +20,9 @@ Known issues / Roadmap
 * Make it totally multi-company aware.
 * Allow to calculate and pay in other currency different from company one.
 * Allow to group by agent when generating invoices.
-
+* We need to add in this module the analytic_tag_ids
+  fields in the invoice form view
+  until https://github.com/odoo/odoo/issues/24702 is fixed.
 
 Bug Tracker
 ===========

--- a/sale_commission/views/account_invoice_view.xml
+++ b/sale_commission/views/account_invoice_view.xml
@@ -23,7 +23,14 @@
                 <field name="commission_free"/>
                 <field name="agents"
                        attrs="{'readonly': [('commission_free', '=', True)]}"/>
+                <!-- We need to add the analytic_tag_ids until https://github.com/odoo/odoo/issues/24702 is fixed-->
+                <field name="analytic_tag_ids"
+                       groups="analytic.group_analytic_accounting"
+                       widget="many2many_tags"
+                       options="{'color_field': 'color'}"/>
+
             </field>
+
         </field>
     </record>
 


### PR DESCRIPTION
Prevents an error when you manually add lines to an invoice. 

Without this fix invoices are unusable.
