### PR TITLE
[FIX] hr_commission: Avoid AccessError on partner form

### DIFF
--- a/hr_commission/__openerp__.py
+++ b/hr_commission/__openerp__.py
@@ -20,7 +20,7 @@
 
 {
     'name': 'HR commissions',
-    'version': '8.0.1.0.0',
+    'version': '8.0.2.0.0',
     'author': 'Serv. Tecnol. Avanzados - Pedro M. Baeza, '
               'Odoo Community Association (OCA)',
     "category": "Human Resources",

--- a/hr_commission/models/res_partner.py
+++ b/hr_commission/models/res_partner.py
@@ -30,17 +30,17 @@ class ResPartner(models.Model):
         selection_add=[("salesman", "Salesman (employee)")])
     employee = fields.Many2one(
         comodel_name="hr.employee", compute="_get_employee")
-    users = fields.One2many(comodel_name="res.users",
-                            inverse_name="partner_id")
 
     @api.one
-    @api.depends('users')
+    @api.depends('user_ids')
     def _get_employee(self):
-        self.employee = False
-        if len(self.users) == 1 and len(self.users[0].employee_ids) == 1:
-            self.employee = self.users[0].employee_ids[0]
+        try:
+            self.employee = self.user_ids[:1].employee_ids[:1]
+        except exceptions.AccessError:
+            # You have no access to employees; then it's empty
+            pass
 
-    @api.constrains('agent_type', 'users')
+    @api.constrains('agent_type', 'user_ids')
     def _check_employee(self):
         if self.agent_type == 'salesman' and not self.employee:
             raise exceptions.ValidationError(


### PR DESCRIPTION
If user has no access to employees, the field should be empty, but he should still be able to user ``res.partner`` form and everything else.

@Tecnativa