### PR TITLE
[11.0] FIX sale_commission the following use case

### DIFF
--- a/sale_commission/__manifest__.py
+++ b/sale_commission/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Sales commissions',
-    'version': '11.0.1.3.0',
+    'version': '11.0.1.4.0',
     'author': 'Odoo Community Association (OCA)',
     'category': 'Sales Management',
     'license': 'AGPL-3',

--- a/sale_commission/models/res_partner.py
+++ b/sale_commission/models/res_partner.py
@@ -10,7 +10,7 @@ class ResPartner(models.Model):
     agents = fields.Many2many(
         comodel_name="res.partner", relation="partner_agent_rel",
         column1="partner_id", column2="agent_id",
-        domain="[('agent', '=', True)]")
+        domain=[('agent', '=', True)])
     # Fields for the partner when it acts as an agent
     agent = fields.Boolean(
         string="Creditor/Agent",


### PR DESCRIPTION
 - Go to Sales -> Customers
 - Filters -> Add Custom Filter: Agents contains test

Get

odoo/addons/base/res/res_partner.py", line 647, in name_search
    where_query = self._where_calc(args)
odoo/models.py", line 4038, in _where_calc
    domain = [('active', '=', 1)] + domain
TypeError: can only concatenate list (not "str") to list