### PR TITLE
[10.0][FIX] sale_commission: Journal check

### DIFF
--- a/sale_commission/__manifest__.py
+++ b/sale_commission/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Sales commissions',
-    'version': '10.0.2.0.0',
+    'version': '10.0.2.1.0',
     'author': 'Odoo Community Association (OCA),'
               'Tecnativa,'
               'AvanzOSC,'

--- a/sale_commission/models/sale_order.py
+++ b/sale_commission/models/sale_order.py
@@ -66,16 +66,9 @@ class SaleOrderLineAgent(models.Model):
     @api.depends('object_id.price_subtotal')
     def _compute_amount(self):
         for line in self:
-            line.amount = 0.0
-            if (not line.object_id.product_id.commission_free and
-                    line.commission):
-                if line.commission.amount_base_type == 'net_amount':
-                    subtotal = (line.object_id.price_subtotal -
-                                (line.object_id.product_id.standard_price *
-                                 line.object_id.product_uom_qty))
-                else:
-                    subtotal = line.object_id.price_subtotal
-                if line.commission.commission_type == 'fixed':
-                    line.amount = subtotal * (line.commission.fix_qty / 100.0)
-                else:
-                    line.amount = line.commission.calculate_section(subtotal)
+            line.amount = self._get_commission_amount(
+                line.commission,
+                line.object_id.price_subtotal,
+                line.object_id.product_id.commission_free,
+                line.object_id.product_id,
+                line.object_id.product_uom_qty)

--- a/sale_commission/models/settlement.py
+++ b/sale_commission/models/settlement.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from odoo import api, exceptions, fields, models, _
+from odoo.exceptions import UserError
 
 
 class Settlement(models.Model):
@@ -123,6 +124,10 @@ class Settlement(models.Model):
             invoice_journal = (journal if
                                (settlement.total + extra_total) >= 0 else
                                False)
+            if not invoice_journal:
+                raise UserError(
+                    _('Journal %s is not applicable for quantity %s')
+                    % (journal.display_name, settlement.total + extra_total))
             invoice_vals = self._prepare_invoice_header(
                 settlement, invoice_journal, date=date)
             invoice = invoice_obj.create(invoice_vals)

--- a/sale_commission/tests/test_sale_commission.py
+++ b/sale_commission/tests/test_sale_commission.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from odoo import exceptions, fields
-import openerp.tests.common as common
+import odoo.tests.common as common
 import dateutil.relativedelta
 
 
@@ -285,6 +285,7 @@ class TestSaleCommission(common.TransactionCase):
         wizard2 = self.make_inv_model.create({'product': 1})
         wizard2.button_create()
         settlements = self.settle_model.search([('state', '=', 'invoiced')])
+        self.assertTrue(settlements)
         for settlement in settlements:
             self.assertNotEquals(len(settlement.invoice), 0,
                                  "Settlements need to be in Invoiced State.")


### PR DESCRIPTION
Automated tests of 10.0 are failing:
```
ERROR: test_sale_commission_net_amount_invoice (odoo.addons.sale_commission.tests.test_sale_commission.TestSaleCommission)
Traceback (most recent call last):
`   File "/home/travis/build/OCA/commission/sale_commission/tests/test_sale_commission.py", line 286, in test_sale_commission_net_amount_invoice
`     wizard2.button_create()
`   File "/home/travis/build/OCA/commission/sale_commission/wizard/wizard_invoice.py", line 46, in button_create
`     self.journal, self.product, date=self.date)
`   File "/home/travis/build/OCA/commission/sale_commission/models/settlement.py", line 127, in make_invoices
`     settlement, invoice_journal, date=date)
`   File "/home/travis/build/OCA/commission/sale_commission/models/settlement.py", line 71, in _prepare_invoice_header
`     'type': ('in_invoice' if journal.type == 'purchase' else
` AttributeError: 'bool' object has no attribute 'type'
```
This is because the journal suggested by the wizard is discarded in https://github.com/OCA/commission/blob/10.0/sale_commission/models/settlement.py#L123.

The `settlement.total + extra_total` was negative because `invoice.line.product_id.standard_price` was being used instead of `invoice.line.price_unit`