### PR TITLE
[FIX]sale_commission: Add security rules to avoid multicompany errors

### DIFF
--- a/sale_commission/__manifest__.py
+++ b/sale_commission/__manifest__.py
@@ -18,6 +18,7 @@
     ],
     'data': [
         'security/ir.model.access.csv',
+        'security/commission_security.xml',
         'views/sale_commission_view.xml',
         'views/sale_commission_mixin_views.xml',
         'views/product_template_view.xml',

--- a/sale_commission/models/sale_commission.py
+++ b/sale_commission/models/sale_commission.py
@@ -25,6 +25,11 @@ class SaleCommission(models.Model):
         string='Base', required=True, default='gross_amount')
     settlements = fields.Many2many(
         comodel_name='sale.commission.settlement')
+    company_id = fields.Many2one(
+        comodel_name='res.company',
+        default=lambda self: self.env.user.company_id,
+        required=True
+    )
 
     @api.multi
     def calculate_section(self, base):

--- a/sale_commission/security/commission_security.xml
+++ b/sale_commission/security/commission_security.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record id="sale_commission_multicompany_rule" model="ir.rule">
+            <field name="name">Sale commission multi-company</field>
+            <field name="model_id" ref="model_sale_commission"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
+        </record>
+
+        <record id="account_invoice_line_agent_multicompany_rule" model="ir.rule">
+            <field name="name">Invoice line agent multi-company</field>
+            <field name="model_id" ref="model_account_invoice_line_agent"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
+        </record>
+
+        <record id="sale_commission_settlement_multicompany_rule" model="ir.rule">
+            <field name="name">Settlement multi-company</field>
+            <field name="model_id" ref="model_sale_commission_settlement"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
+        </record>
+
+        <record id="sale_commission_settlement_line_multicompany_rule" model="ir.rule">
+            <field name="name">Settlement line multi-company</field>
+            <field name="model_id" ref="model_sale_commission_settlement_line"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
+        </record>
+
+    </data>
+</odoo>


### PR DESCRIPTION
If you do a settlement, in a company A, and there are account.invoice.line.agent, in both company A and B (B is not a child company of A), When we do the settlements (by company) we need to avoid searching lines in the B company, because of security error reading field company_id of the related object. The next code in the wizard seattle, fail with multi company because of  the line 'lambda r: r.object_id.company_id == company.'

```
for company in agent_lines.mapped('company_id'):
    agent_lines_company = agent_lines.filtered(
        'lambda r: r.object_id.company_id == company)
```
Agent lines must be of the same or child company, never a brother company.