### PR TITLE
[commission] Fix TypeError: not all arguments are converted during string formatting

### DIFF
--- a/sale_commission/__manifest__.py
+++ b/sale_commission/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Sales commissions',
-    'version': '10.0.2.1.0',
+    'version': '10.0.2.1.1',
     'author': 'Odoo Community Association (OCA),'
               'Tecnativa,'
               'AvanzOSC,'

--- a/sale_commission/models/sale_commission_mixin.py
+++ b/sale_commission/models/sale_commission_mixin.py
@@ -55,7 +55,7 @@ class SaleCommissionMixin(models.AbstractModel):
             else:
                 line.commission_status = _(
                     "%s commission agents"
-                ) % len(line.agents)
+                ).format(str(len(line.agents)))
 
     @api.model
     def _filter_agent_vals(self, vals):


### PR DESCRIPTION
I'm getting TypeError: not all arguments are converted during string formatting when assigning more than 1 agent to a sale order. This patch fixes the issue.