### PR TITLE
[10.0][FIX] sale_commission: Strictly check commission type

### DIFF
--- a/sale_commission/__manifest__.py
+++ b/sale_commission/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Sales commissions',
-    'version': '10.0.2.1.0',
+    'version': '10.0.2.1.1',
     'author': 'Odoo Community Association (OCA),'
               'Tecnativa,'
               'AvanzOSC,'

--- a/sale_commission/models/sale_commission_mixin.py
+++ b/sale_commission/models/sale_commission_mixin.py
@@ -152,6 +152,6 @@ class SaleCommissionLineMixin(models.AbstractModel):
 
             if commission.commission_type == 'fixed':
                 amount = amount_base * (commission.fix_qty / 100.0)
-            else:
+            elif commission.commission_type == 'section':
                 amount = commission.calculate_section(amount_base)
         return amount


### PR DESCRIPTION
Other modules can extend the `commission_type` selection, but we don't want to compute the amount using `section` computations everytime it is not `'fixed'`