### PR TITLE
[10.0][FIX] sale_comission: Fix tests

### DIFF
--- a/sale_commission/tests/test_sale_commission.py
+++ b/sale_commission/tests/test_sale_commission.py
@@ -280,7 +280,7 @@ class TestSaleCommission(common.TransactionCase):
             self.assertEquals(invoice.state, 'open')
         wizard = self.make_settle_model.create(
             {'date_to': (fields.Datetime.from_string(fields.Datetime.now()) +
-                         dateutil.relativedelta.relativedelta(months=1))})
+                         dateutil.relativedelta.relativedelta(years=1))})
         wizard.action_settle()
         wizard2 = self.make_inv_model.create({'product': 1})
         wizard2.button_create()


### PR DESCRIPTION
sale_order4 is using agent with 'annual' commission, so in order to have settlements, we have to call the wizard with date_to equal to next year