### PR TITLE
[FIX] Fixed a single DEADLY translation...

### DIFF
--- a/sale_commission/i18n/it.po
+++ b/sale_commission/i18n/it.po
@@ -26,9 +26,9 @@ msgstr ""
 
 #. module: sale_commission
 #: code:addons/sale_commission/models/sale_commission_mixin.py:65
-#, fuzzy, python-format
+#, python-format
 msgid "%s commission agents"
-msgstr "Gestione Agenti/Commissioni"
+msgstr "%s commissioni agenti"
 
 #. module: sale_commission
 #: model:ir.ui.view,arch_db:sale_commission.sale_commission_make_invoice_form


### PR DESCRIPTION
... without placeholder causing Odoo raising `TypeError` exception.

```
Errore:
Odoo Server Error

Traceback (most recent call last):
 File "/usr/lib/python3/dist-packages/odoo/fields.py", line 927, in __get__
   value = record.env.cache.get(record, self)
 File "/usr/lib/python3/dist-packages/odoo/api.py", line 967, in get
   value = self._data[key][field][record.id]
KeyError: 20639

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
 File "/usr/lib/python3/dist-packages/odoo/http.py", line 651, in _handle_exception
   return super(JsonRequest, self)._handle_exception(exception)
 File "/usr/lib/python3/dist-packages/odoo/http.py", line 310, in _handle_exception
   raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
 File "/usr/lib/python3/dist-packages/odoo/tools/pycompat.py", line 87, in reraise
   raise value
 File "/usr/lib/python3/dist-packages/odoo/http.py", line 693, in dispatch
   result = self._call_function(**self.params)
 File "/usr/lib/python3/dist-packages/odoo/http.py", line 342, in _call_function
   return checked_call(self.db, *args, **kwargs)
 File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 97, in wrapper
   return f(dbname, *args, **kwargs)
 File "/usr/lib/python3/dist-packages/odoo/http.py", line 335, in checked_call
   result = self.endpoint(*a, **kw)
 File "/usr/lib/python3/dist-packages/odoo/http.py", line 937, in __call__
   return self.method(*args, **kw)
 File "/usr/lib/python3/dist-packages/odoo/http.py", line 515, in response_wrap
   response = f(*args, **kw)
 File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/main.py", line 934, in call_kw
   return self._call_kw(model, method, args, kwargs)
 File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/main.py", line 926, in _call_kw
   return call_kw(request.env[model], method, args, kwargs)
 File "/usr/lib/python3/dist-packages/odoo/api.py", line 689, in call_kw
   return call_kw_multi(method, model, args, kwargs)
 File "/usr/lib/python3/dist-packages/odoo/api.py", line 680, in call_kw_multi
   result = method(recs, *args, **kwargs)
 File "/usr/lib/python3/dist-packages/odoo/models.py", line 2606, in read
   data[record][name] = convert(record[name], record, use_name_get)
 File "/usr/lib/python3/dist-packages/odoo/models.py", line 4763, in __getitem__
   return self._fields[key].__get__(self, type(self))
 File "/usr/lib/python3/dist-packages/odoo/fields.py", line 931, in __get__
   self.determine_value(record)
 File "/usr/lib/python3/dist-packages/odoo/fields.py", line 1042, in determine_value
   self.compute_value(recs)
 File "/usr/lib/python3/dist-packages/odoo/fields.py", line 998, in compute_value
   self._compute_value(records)
 File "/usr/lib/python3/dist-packages/odoo/fields.py", line 989, in _compute_value
   getattr(records, self.compute)()
 File "/usr/local/lib/python3.5/dist-packages/odoo/addons/sale_commission/models/sale_commission_mixin.py", line 67, in _compute_commission_status
   ) % len(line.agents)
TypeError: not all arguments converted during string formatting
```