### PR TITLE
[FIX] sale_commission: _compute_commission_status

### DIFF
--- a/sale_commission/models/sale_commission_mixin.py
+++ b/sale_commission/models/sale_commission_mixin.py
@@ -55,7 +55,8 @@ class SaleCommissionMixin(models.AbstractModel):
             else:
                 line.commission_status = _(
                     "%s commission agents"
-                ) % len(line.agents)
+                    % len(line.agents)
+                )
 
     @api.model
     def _filter_agent_vals(self, vals):


### PR DESCRIPTION
When calculating the commission status with more than one agent error was occurring when calculating the string for the commission_status field.

```
Traceback (most recent call last):
  File "/home/raphael/moober/v10/odoo/odoo/http.py", line 642, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/raphael/moober/v10/odoo/odoo/http.py", line 684, in dispatch
    result = self._call_function(**self.params)
  File "/home/raphael/moober/v10/odoo/odoo/http.py", line 334, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/raphael/moober/v10/odoo/odoo/service/model.py", line 101, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/raphael/moober/v10/odoo/odoo/http.py", line 327, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/raphael/moober/v10/odoo/odoo/http.py", line 942, in __call__
    return self.method(*args, **kw)
  File "/home/raphael/moober/v10/odoo/odoo/http.py", line 507, in response_wrap
    response = f(*args, **kw)
  File "/home/raphael/moober/v10/odoo/addons/web/controllers/main.py", line 895, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/raphael/moober/v10/odoo/addons/web/controllers/main.py", line 887, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/raphael/moober/v10/odoo/odoo/api.py", line 689, in call_kw
    return call_kw_multi(method, model, args, kwargs)
  File "/home/raphael/moober/v10/odoo/odoo/api.py", line 680, in call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/raphael/moober/v10/odoo/odoo/models.py", line 3033, in read
    data[record][name] = convert(record[name], record, use_name_get)
  File "/home/raphael/moober/v10/odoo/odoo/models.py", line 5241, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/home/raphael/moober/v10/odoo/odoo/fields.py", line 915, in __get__
    self.determine_value(record)
  File "/home/raphael/moober/v10/odoo/odoo/fields.py", line 1027, in determine_value
    self.compute_value(recs)
  File "/home/raphael/moober/v10/odoo/odoo/fields.py", line 981, in compute_value
    self._compute_value(records)
  File "/home/raphael/moober/v10/odoo/odoo/fields.py", line 972, in _compute_value
    getattr(records, self.compute)()
  File "/home/raphael/moober/v10/commons-addons/commission/sale_commission/models/sale_commission_mixin.py", line 58, in _compute_commission_status
    ) % len(line.agents)
TypeError: not all arguments converted during string formatting
```