### PR TITLE
[10.0][FIX] sale_commission: Add view context by code

### DIFF
--- a/sale_commission/views/sale_order_view.xml
+++ b/sale_commission/views/sale_order_view.xml
@@ -6,9 +6,6 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
-            <field name="order_line" position="attributes">
-                <attribute name="context">{'partner_id': partner_id}</attribute>
-            </field>
             <xpath expr="//field[@name='order_line']/tree" position="attributes">
                 <attribute name="editable"/>
             </xpath>


### PR DESCRIPTION
As Odoo hasn't got any mechanism for adding several elements to the context dict, using XML view tools, we can have our context replaced by other module doing the same operation.

Example: https://github.com/OCA/sale-workflow/blob/8428446c79981aee281eb1773ff84c5a32d02067/sale_order_line_sequence/views/sale_view.xml#L13

Thus, we avoid the problem adding the context by code, as this context is vital for having default agents commissions populated on the sales order lines.

cc @Tecnativa