### PR TITLE
[13.0][FIX] sale_commission: fixing error on append instruction

### DIFF
--- a/sale_commission/migrations/13.0.1.0.0/pre-migration.py
+++ b/sale_commission/migrations/13.0.1.0.0/pre-migration.py
@@ -39,5 +39,5 @@ def migrate(env, version):
     renamed_fields = []
     for model in renamings:
         for old_field, new_field in renamings[model]:
-            renamed_fields.append(model, model.replace(".", "_"), old_field, new_field)
+            renamed_fields.append((model, model.replace(".", "_"), old_field, new_field))
     openupgrade.rename_fields(env, renamed_fields)


### PR DESCRIPTION
without this fix, during the migration appears this error:
`TypeError: append() takes exactly one argument (4 given)`