### PR TITLE
[13.0][FIX] sale_commission: fixing view_res_partner_filter

### DIFF
--- a/sale_commission/views/res_partner_view.xml
+++ b/sale_commission/views/res_partner_view.xml
@@ -64,10 +64,10 @@
             </page>
         </field>
     </record>
-    <record id="view_res_partner_filter" model="ir.ui.view">
+    <record id="res_partner_view_search" model="ir.ui.view">
         <field name="name">res.partner.select</field>
         <field name="model">res.partner</field>
-        <field name="inherit_id" ref="base.view_res_partner_filter" />
+        <field name="inherit_id" ref="account.res_partner_view_search" />
         <field name="arch" type="xml">
             <filter name="supplier" position="after">
                 <filter
@@ -87,7 +87,7 @@
         <field
             name="context"
         >{"search_default_agent": 1, 'default_agent': 1, 'default_customer': 0, 'default_supplier': 1}</field>
-        <field name="search_view_id" ref="view_res_partner_filter" />
+        <field name="search_view_id" ref="res_partner_view_search" />
     </record>
     <menuitem
         id="menu_agent_form"


### PR DESCRIPTION
`<filter name="supplier">` was removed in https://github.com/odoo/odoo/commit/3e97cff7797c4f7e695d20def6b920561b6a6525

`<filter name="inactive">` is the first available field