### PR TITLE
[IMP] sale_commission: Remove required attribute in settlement field. Added to view

### DIFF
--- a/sale_commission/models/res_partner.py
+++ b/sale_commission/models/res_partner.py
@@ -25,10 +25,7 @@ class ResPartner(models.Model):
         help="Check this field if the partner is a creditor or an agent.",
     )
     agent_type = fields.Selection(
-        selection=[("agent", "External agent")],
-        string="Type",
-        required=True,
-        default="agent",
+        selection=[("agent", "External agent")], string="Type", default="agent",
     )
     commission_id = fields.Many2one(
         string="Commission",
@@ -46,7 +43,6 @@ class ResPartner(models.Model):
         ],
         string="Settlement period",
         default="monthly",
-        required=True,
     )
     settlement_ids = fields.One2many(
         comodel_name="sale.commission.settlement",

--- a/sale_commission/views/res_partner_view.xml
+++ b/sale_commission/views/res_partner_view.xml
@@ -32,14 +32,14 @@
                 >
                     <group>
                         <group>
-                            <field name="agent_type" />
+                            <field name="agent_type" required="1" />
                             <field
                                 name="commission_id"
                                 attrs="{'required': [('agent', '=', True)]}"
                             />
                         </group>
                         <group>
-                            <field name="settlement" />
+                            <field name="settlement" required="1" />
                         </group>
                         <!-- TODO: Change it to smart-button -->
                         <group


### PR DESCRIPTION
When updating a table, modules that don't have the `required=True` setting of a field in their scope issue an `ALTER TABLE` at least twice per module. This blocks the entire table.

This module was doing that, and since the `res.partner` model is so ubiquitous, this was blocking concurrent updates.

By moving the required attribute to the views, the UX is the same, but concurrent updates work fine again.

@Tecnativa TT27096
FWport of https://github.com/OCA/commission/pull/270