### PR TITLE
[13.0][FIX] Context overriden from invoice_line_ids

### DIFF
--- a/sale_commission/views/account_move_views.xml
+++ b/sale_commission/views/account_move_views.xml
@@ -37,9 +37,6 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
-            <field name="invoice_line_ids" position="attributes">
-                <attribute name="context">{'partner_id': partner_id}</attribute>
-            </field>
             <xpath
                 expr="//field[@name='invoice_line_ids']/tree//field[@name='price_subtotal']"
                 position="after"


### PR DESCRIPTION
We've found two problems which take place when an invoice is created.

- When adding an invoice lines, products that can be purchased are shown (if only purchase_ok is ticked, product is not showing up).

- If the customer has a different language from the default and the product being added has a description in the customer's language, the description is not displayed in the customer's language (example: default language is spanish, but customer has english and the product also has the description in english).

The solution has been keeping the core context of the invoice_lines + adding the partner_id which this module adds.

@pedrobaeza can you review this?