### PR TITLE
[13.0][FIX] sale_commission: Fix tests

### DIFF
--- a/sale_commission/tests/test_sale_commission.py
+++ b/sale_commission/tests/test_sale_commission.py
@@ -319,6 +319,7 @@ class TestSaleCommission(SavepointCase):
             self.env["account.move"].with_context(default_type="in_invoice")
         )
         move_form.partner_id = self.partner
+        move_form.ref = "sale_comission_TEST"
         with move_form.invoice_line_ids.new() as line_form:
             line_form.product_id = self.product
             line_form.quantity = 1


### PR DESCRIPTION
`ref` field is required for supplier invoices. We should create the object correctly in the tests.

@Tecnativa
TT28236

ping @pedrobaeza @victoralmau 