### PR TITLE
[13.0][FIX] sale_commission: Invoice lines default values

### DIFF
--- a/sale_commission/views/account_move_views.xml
+++ b/sale_commission/views/account_move_views.xml
@@ -38,7 +38,7 @@
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
             <field name="invoice_line_ids" position="attributes">
-                <attribute name="context">{'partner_id': partner_id}</attribute>
+                <attribute name="context">{'partner_id': partner_id, 'default_type': context.get('default_type'), 'journal_id': journal_id, 'default_partner_id': commercial_partner_id, 'default_currency_id': currency_id != company_currency_id and currency_id or False}</attribute>
             </field>
             <xpath
                 expr="//field[@name='invoice_line_ids']/tree//field[@name='price_subtotal']"


### PR DESCRIPTION
We have detected that when creating an invoice manually, some fields are not filled in the lines by default, such as the partner_id field, which are filled in without having this module installed and this is causing us other problems (this happens because this module modifies the context of the invoice_line_ids field).

We understand that for previous versions there was no problem, since the invoices and accounting entries were separated and when an invoice was validated and the entry generated, they were filled in automatically.
