### PR TITLE
[FIX] sale_commission_formula: test

### DIFF
--- a/sale_commission_formula/tests/test_commission_formula.py
+++ b/sale_commission_formula/tests/test_commission_formula.py
@@ -78,6 +78,5 @@ class TestCommissionFormula(TransactionCase):
         )
         # we test the '5% + 10% extra' commissions on the invoice too
         self.assertEqual(41.25, invoice.commission_total)
-        invoice.post()
         reverse = invoice._reverse_moves(cancel=True)
         self.assertEqual(-41.25, reverse.commission_total)


### PR DESCRIPTION
The invoice post() was done twice, which is unnecessary and with the
recent upstream changes raises an exception

cc @Tecnativa TT29179