### PR TITLE
[12.0][FIX] Commission fields should required only if partner is agent

### DIFF
--- a/sale_commission/views/res_partner_view.xml
+++ b/sale_commission/views/res_partner_view.xml
@@ -23,12 +23,12 @@
                       attrs="{'invisible': [('agent', '=', False)]}">
                     <group>
                         <group>
-                            <field name="agent_type" required="1"/>
+                            <field name="agent_type" attrs="{'required': [('agent', '=', True)]}"/>
                             <field name="commission"
                                    attrs="{'required': [('agent', '=', True)]}"/>
                         </group>
                         <group>
-                            <field name="settlement" required="1"/>
+                            <field name="settlement" attrs="{'required': [('agent', '=', True)]}"/>
                         </group>
                         <group colspan="4"
                                string="Settlements">


### PR DESCRIPTION
When some module creates one partners or load by XML file, the fields agent_type and settlement are null, if you edit in interface this partner and it is not a sale agent you can't save because these fields required.

I added the required using "attrs" attribute in these fields.