### PR TITLE
[13.0] FIX sale_commission preventing to cancel invoice with settled commiss…

### DIFF
--- a/sale_commission/models/account_move.py
+++ b/sale_commission/models/account_move.py
@@ -27,7 +27,12 @@ class AccountMove(models.Model):
                 record.commission_total += sum(x.amount for x in line.agent_ids)
 
     def button_cancel(self):
-        """Put settlements associated to the invoices in exception."""
+        """Put settlements associated to the invoices in exception
+        and check settled lines"""
+        if any(self.mapped("invoice_line_ids.any_settled")):
+            raise exceptions.ValidationError(
+                _("You can't cancel an invoice with settled lines"),
+            )
         self.settlement_id.state = "except_invoice"
         return super().button_cancel()
 


### PR DESCRIPTION
…ion lines.

Steps to reproduce:

 - Create an agent
 - Create and validate an invoice setting that agent
 - Settle the commission
 - Cancel the invoice

Observed: the invoice is canceled

Desired: cancellation is blocked