### PR TITLE
[12.0] IMP sale_commission sale_commission allowing to add agents only by view_sale_commission_mixin_agent_only, aligning to 13.0

### DIFF
--- a/sale_commission/views/sale_order_view.xml
+++ b/sale_commission/views/sale_order_view.xml
@@ -19,8 +19,6 @@
             </xpath>
             <xpath expr="//field[@name='order_line']/form//field[@name='customer_lead']/.." position="after">
                 <field name="commission_free"/>
-                <field name="agents"
-                       attrs="{'readonly': [('commission_free', '=', True)]}"/>
             </xpath>
             <field name="amount_total" position="after">
                 <field name="commission_total"


### PR DESCRIPTION
Also fix the following use case:

 - Create a quotation template with a quotation line
 - Create a quotation selecting the new template > the line will be added
 - Open line form and try to add an agent

Get TypeError: fieldsInfo is undefined