### PR TITLE
[13.0][OU-IMP] sale_commmission: compute fields using SQL

### DIFF
--- a/sale_commission/migrations/13.0.1.0.0/pre-migration.py
+++ b/sale_commission/migrations/13.0.1.0.0/pre-migration.py
@@ -47,6 +47,30 @@ _field_adds = [
         False,
         "sale_commission",
     ),
+    (
+        "invoice_id",
+        "sale.commission.settlement",
+        "sale_commission_settlement",
+        "many2one",
+        False,
+        "sale_commission",
+    ),
+    (
+        "commission_total",
+        "account.move",
+        "account_move",
+        "float",
+        False,
+        "sale_commission",
+    ),
+    (
+        "commission_free",
+        "account.move.line",
+        "account_move_line",
+        "boolean",
+        False,
+        "sale_commission",
+    ),
 ]
 
 


### PR DESCRIPTION
I found other fields that took long time to compute. Now it should be faster. On my case, from 17 minutes to 3 minutes