### PR TITLE
[14.0][FIX] sale_commission: amount compute

### DIFF
--- a/sale_commission/models/account_move.py
+++ b/sale_commission/models/account_move.py
@@ -137,7 +137,11 @@ class AccountInvoiceLineAgent(models.Model):
         readonly=True,
     )
 
-    @api.depends("object_id.price_subtotal", "object_id.product_id.commission_free")
+    @api.depends(
+        "object_id.price_subtotal",
+        "object_id.product_id.commission_free",
+        "commission_id",
+    )
     def _compute_amount(self):
         for line in self:
             inv_line = line.object_id


### PR DESCRIPTION
The amount field was not depending on the commission_id field so no matter how much it was changed it was not reflected in the invoice line