### PR TITLE
[FIX] sale_commission: Fix grouped invoices creation

### DIFF
--- a/sale_commission/models/account_move.py
+++ b/sale_commission/models/account_move.py
@@ -93,6 +93,17 @@ class AccountMoveLine(models.Model):
                     record.move_id.partner_id
                 )
 
+    def _copy_data_extend_business_fields(self, values):
+        """
+        We don't want to loose the settlement from the line when reversing the line if
+        it was a refund.
+        We need to include it, but as we don't want change it everytime, we will add
+        the data when a context key is passed
+        """
+        super()._copy_data_extend_business_fields(values)
+        if self.settlement_id and self.env.context.get("include_settlement", False):
+            values["settlement_id"] = self.settlement_id.id
+
 
 class AccountInvoiceLineAgent(models.Model):
     _inherit = "sale.commission.line.mixin"

--- a/sale_commission/models/settlement.py
+++ b/sale_commission/models/settlement.py
@@ -96,8 +96,9 @@ class Settlement(models.Model):
         return self[0].agent_id
 
     def _prepare_invoice(self, journal, product, date=False):
-        move_type = "in_invoice" if sum(self.mapped("total")) >= 0 else "in_refund"
-        move_form = Form(self.env["account.move"].with_context(default_type=move_type))
+        move_form = Form(
+            self.env["account.move"].with_context(default_type="in_invoice")
+        )
         if date:
             move_form.invoice_date = date
         partner = self._get_invoice_partner()
@@ -106,7 +107,7 @@ class Settlement(models.Model):
         for settlement in self:
             with move_form.invoice_line_ids.new() as line_form:
                 line_form.product_id = product
-                line_form.quantity = 1
+                line_form.quantity = -1 if settlement.total < 0 else 1
                 line_form.price_unit = abs(settlement.total)
                 # Put period string
                 lang = self.env["res.lang"].search(
@@ -156,6 +157,9 @@ class Settlement(models.Model):
             invoice_vals = settlement._prepare_invoice(journal, product, date)
             invoice_vals_list.append(invoice_vals)
         invoices = self.env["account.move"].create(invoice_vals_list)
+        invoices.sudo().filtered(lambda m: m.amount_total < 0).with_context(
+            include_settlement=True
+        ).action_switch_invoice_into_refund_credit_note()
         self.write({"state": "invoiced"})
         return invoices
 


### PR DESCRIPTION
When using grouped invoices, an error could be created because sign was changed with type. Now it should work properly, as the sign is changed at the end.

For example, if you had two settlements, one of 10€ and one of -10€, the old result was an invoice of 20€. Now, the result is an invoice of 0€.