### PR TITLE
[14.0][FIX] Change related invoice_date field of invoice.line.agent

### DIFF
--- a/sale_commission/models/account_move.py
+++ b/sale_commission/models/account_move.py
@@ -137,7 +137,7 @@ class AccountInvoiceLineAgent(models.Model):
     )
     invoice_date = fields.Date(
         string="Invoice date",
-        related="invoice_id.date",
+        related="invoice_id.invoice_date",
         store=True,
         readonly=True,
     )


### PR DESCRIPTION
Currently, the field 'invoice_date' of the model 'account.invoice.line.agent' is related with the field 'date' of the 'account.move', but the more appropriate is the 'invoice_date' of the 'account.move' model. This last field can be edited by user on view and maybe cause a informations divergence with the relatory, because the date field is not editable on the invoice and only represents the creation date and not the actual date of the invoice. This change would keep the same logic that existed in v12.




