### PR TITLE
[12.0][REF] The way the commission_free is taken

### DIFF
--- a/sale_commission/models/account_invoice.py
+++ b/sale_commission/models/account_invoice.py
@@ -164,7 +164,7 @@ class AccountInvoiceLineAgent(models.Model):
         readonly=True,
     )
 
-    @api.depends('object_id.price_subtotal')
+    @api.depends('object_id.price_subtotal', 'object_id.commission_free')
     def _compute_amount(self):
         for line in self:
             inv_line = line.object_id

--- a/sale_commission/models/sale_commission_mixin.py
+++ b/sale_commission/models/sale_commission_mixin.py
@@ -147,7 +147,7 @@ class SaleCommissionLineMixin(models.AbstractModel):
         compute methods of children models.
         """
         self.ensure_one()
-        if product.commission_free or not commission:
+        if self.object_id.commission_free or not commission:
             return 0.0
         if commission.amount_base_type == 'net_amount':
             # If subtotal (sale_price * quantity) is less than


### PR DESCRIPTION
This PR changes the way the "commission_free" is taken when calculating the amount, instead of taking the product, it is taken directly from the invoice_line (object_id) , which has the commission_free as a related to the product's commission_free.

This will not change any behavior, but it makes it easier for those who inherit the module, we are making a module for Brazil where the commission_free becomes a computed and it will not only depend on the product, but also on other information.