### PR TITLE
[FIX] sale_commission: fix down payment invoice agents commission calculation

### DIFF
--- a/sale_commission/models/account_move.py
+++ b/sale_commission/models/account_move.py
@@ -99,6 +99,7 @@ class AccountMoveLine(models.Model):
 
     agent_ids = fields.One2many(comodel_name="account.invoice.line.agent")
     any_settled = fields.Boolean(compute="_compute_any_settled")
+    is_downpayment = fields.Boolean(default=False)
     settlement_id = fields.Many2one(
         comodel_name="sale.commission.settlement",
         help="Settlement that generates this invoice line",
@@ -116,10 +117,44 @@ class AccountMoveLine(models.Model):
         for record in self.filtered(
             lambda x: x.move_id.partner_id and x.move_id.move_type[:3] == "out"
         ):
-            if not record.commission_free and record.product_id:
-                record.agent_ids = record._prepare_agents_vals_partner(
-                    record.move_id.partner_id
+            if record.sale_line_ids and record.sale_line_ids.is_downpayment:
+                # Down payment invoice
+                agent_ids = record._prepare_agents_vals_down_payment()
+                record.update({"is_downpayment": True, "agent_ids": agent_ids})
+            else:
+                # Regular invoice
+                if not record.commission_free and record.product_id:
+                    record.agent_ids = record._prepare_agents_vals_partner(
+                        record.move_id.partner_id
+                    )
+
+    def _prepare_agents_vals_down_payment(self):
+        # Add agent lines with amount > 0 and with total commission amount
+        self.sale_line_ids.ensure_one()
+        sale_order_id = self.sale_line_ids.order_id
+        agent_sol_ids = sale_order_id.order_line.filtered(
+            lambda x: x.is_downpayment is False and x.product_id and x.agent_ids
+        )
+        sol_agents = agent_sol_ids.mapped("agent_ids")
+        grouped_agent_ids = sol_agents.read_group(
+            fields=["agent_id", "amount"],
+            domain=[("amount", ">", 0)],
+            groupby=["agent_id"],
+        )
+        res = []
+        for agent_line in grouped_agent_ids:
+            res.append(
+                (
+                    0,
+                    0,
+                    {
+                        "agent_id": agent_line["agent_id"][0],
+                        "amount": 0,
+                        "downpayment_base_amount": agent_line["amount"],
+                    },
                 )
+            )
+        return res
 
     def _copy_data_extend_business_fields(self, values):
         """
@@ -158,6 +193,15 @@ class AccountInvoiceLineAgent(models.Model):
         column2="settlement_id",
         copy=False,
     )
+    commission_id = fields.Many2one(
+        comodel_name="sale.commission",
+        ondelete="restrict",
+        required=False,
+        compute="_compute_commission_id",
+        store=True,
+        readonly=False,
+        copy=True,
+    )
     settled = fields.Boolean(compute="_compute_settled", store=True)
     company_id = fields.Many2one(
         comodel_name="res.company",
@@ -167,6 +211,9 @@ class AccountInvoiceLineAgent(models.Model):
     currency_id = fields.Many2one(
         related="object_id.currency_id",
         readonly=True,
+    )
+    downpayment_base_amount = fields.Monetary(
+        help="Total agent commission based on Sale Order"
     )
 
     @api.depends(
@@ -221,3 +268,27 @@ class AccountInvoiceLineAgent(models.Model):
             self.commission_id.invoice_state == "paid"
             and self.invoice_id.payment_state not in ["in_payment", "paid"]
         ) or self.invoice_id.state != "posted"
+
+    @api.depends("agent_id")
+    def _compute_commission_id(self):
+        for record in self.filtered(lambda x: not x.object_id.is_downpayment):
+            record.commission_id = record.agent_id.commission_id
+
+    def _get_commission_amount(self, commission, subtotal, product, quantity):
+        # overriden in order to implement down payment logic
+        self.ensure_one()
+        if self.object_id.is_downpayment:
+            sale_order_id = self.object_id.sale_line_ids.order_id
+            ratio = self.object_id.price_total / sale_order_id.amount_total
+            return self.downpayment_base_amount * ratio
+        if product.commission_free or not commission:
+            return 0.0
+        if commission.amount_base_type == "net_amount":
+            # If subtotal (sale_price * quantity) is less than
+            # standard_price * quantity, it means that we are selling at
+            # lower price than we bought, so set amount_base to 0
+            subtotal = max([0, subtotal - product.standard_price * quantity])
+        if commission.commission_type == "fixed":
+            return subtotal * (commission.fix_qty / 100.0)
+        elif commission.commission_type == "section":
+            return commission.calculate_section(subtotal)


### PR DESCRIPTION
In current version of module down payment invoice agent commission calculated wrong way.
Create Sale Order with 2 lines: Product 1 1000$, Product 2 1000$. 
Set agent commission only for 1st line 10% = 100$ for some agent.
Create down payment invoice with total 1500$.
You will get invoice agent commission 10% of 1500$ = 150$, which is higher than his commission in Sale Order (100$).

This PR makes commission calculation: 1500$ is 3/4 of 2000$. Agent commission will be 3/4 of 100$ = 75$.