### PR TITLE
[FIX][15.0] account_commission : Not working "Reset to draft" button

### DIFF
--- a/account_commission/models/commission_settlement.py
+++ b/account_commission/models/commission_settlement.py
@@ -53,7 +53,7 @@ class CommissionSettlement(models.Model):
         return super().action_cancel()
 
     def action_draft(self):
-        self.write({"state": "draft"})
+        self.write({"state": "settled"})
 
     def unlink(self):
         """Allow to delete only cancelled settlements."""


### PR DESCRIPTION
The state in the commission.settlement model is settled, not draft.

I get an error when I press the "Reset to draft" button.