### PR TITLE
[16.0][FIX] commission: Show full settlements table in partner + [IMP] account_commission: Extract lines to settle domain

### DIFF
--- a/account_commission/wizards/commission_make_settle.py
+++ b/account_commission/wizards/commission_make_settle.py
@@ -14,16 +14,20 @@ class CommissionMakeSettle(models.TransientModel):
         ondelete={"sale_invoice": "cascade"},
     )
 
+    def _get_account_settle_domain(self, agent, date_to_agent):
+        return [
+            ("invoice_date", "<", date_to_agent),
+            ("agent_id", "=", agent.id),
+            ("settled", "=", False),
+            ("object_id.display_type", "=", "product"),
+        ]
+
     def _get_agent_lines(self, agent, date_to_agent):
         """Filter sales invoice agent lines for this type of settlement."""
         if self.settlement_type != "sale_invoice":
             return super()._get_agent_lines(agent, date_to_agent)
         return self.env["account.invoice.line.agent"].search(
-            [
-                ("invoice_date", "<", date_to_agent),
-                ("agent_id", "=", agent.id),
-                ("settled", "=", False),
-            ],
+            self._get_account_settle_domain(agent, date_to_agent),
             order="invoice_date",
         )
 

--- a/commission/views/res_partner_views.xml
+++ b/commission/views/res_partner_views.xml
@@ -42,11 +42,11 @@
                             />
                         </group>
                         <group
-                            colspan="4"
+                            colspan="2"
                             string="Settlements"
                             attrs="{'invisible': [('settlement_ids', '=', [])]}"
                         >
-                            <field name="settlement_ids" nolabel="1">
+                            <field colspan="2" name="settlement_ids" nolabel="1">
                                 <tree
                                     decoration-danger="state == 'cancel'"
                                     decoration-success="state == 'invoiced'"


### PR DESCRIPTION
Couple improvements I ran into while playing with the modules a bit more
- The settlements table view in the partner's agent tab was showing incorrectly, without the proper colspan
- Extract the domain used to settle lines and add `("object_id.display_type", "=", "product")` filter, I think there might be other types of `display_type`s to accept, but I was running into a problem where a `payment_term` line I couldn't see in the invoice was being picked up as a line to settle, it has 0 amount so it wouldn't break accounting, but it isn't correct behaviour. Not sure what other types would be correct here, if any