### PR TITLE
[14.0][FIX] sale commission agent restrict fix agent ids pop

### DIFF
--- a/sale_commission_agent_restrict/models/res_partner.py
+++ b/sale_commission_agent_restrict/models/res_partner.py
@@ -46,5 +46,5 @@ class ResPartner(models.Model):
                     ):
                         # do not populate parents agent_ids to child partners
                         res.pop("agent_ids")
-                        break
+                        return res
         return res


### PR DESCRIPTION
FIX: not need to continue loop if it was already removed. Just return.