### PR TITLE
[14.0][IMP] sale_commission - agent lines domain in a specific function

### DIFF
--- a/sale_commission/wizard/wizard_settle.py
+++ b/sale_commission/wizard/wizard_settle.py
@@ -75,7 +75,6 @@ class SaleCommissionMakeSettle(models.TransientModel):
 
     def action_settle(self):
         self.ensure_one()
-        agent_line_obj = self.env["account.invoice.line.agent"]
         settlement_obj = self.env["sale.commission.settlement"]
         settlement_line_obj = self.env["sale.commission.settlement.line"]
         settlement_ids = []
@@ -88,14 +87,7 @@ class SaleCommissionMakeSettle(models.TransientModel):
         for agent in agents:
             date_to_agent = self._get_period_start(agent, date_to)
             # Get non settled invoices
-            agent_lines = agent_line_obj.search(
-                [
-                    ("invoice_date", "<", date_to_agent),
-                    ("agent_id", "=", agent.id),
-                    ("settled", "=", False),
-                ],
-                order="invoice_date",
-            )
+            agent_lines = self._get_agent_lines(agent, date_to_agent)
             for company in agent_lines.mapped("company_id"):
                 agent_lines_company = agent_lines.filtered(
                     lambda r: r.object_id.company_id == company
@@ -138,3 +130,14 @@ class SaleCommissionMakeSettle(models.TransientModel):
                 "res_model": "sale.commission.settlement",
                 "domain": [["id", "in", settlement_ids]],
             }
+
+    def _get_agent_lines(self, agent, date_to_agent):
+        aila = self.env["account.invoice.line.agent"].search(
+            [
+                ("invoice_date", "<", date_to_agent),
+                ("agent_id", "=", agent.id),
+                ("settled", "=", False),
+            ],
+            order="invoice_date",
+        )
+        return aila


### PR DESCRIPTION
We need to edit agent lines domain for a specific payment term defined by a module in `l10n-italy` repo and we thought to add a method to return the domain instead including this in the whole function.
In fact, at the moment, we'd overwrite the whole action_settle method breaking the chain of inheritance.