### PR TITLE
[15.0][FIX] account_commission: Regenerate agents button invisibility

### DIFF
--- a/account_commission/views/account_move_views.xml
+++ b/account_commission/views/account_move_views.xml
@@ -88,9 +88,10 @@
                     name="recompute_lines_agents"
                     type="object"
                     string="Regenerate agents"
-                    states="draft"
                     attrs="{'invisible': [
-                        ('move_type', 'not in', ['out_invoice', 'out_refund'])
+                        '|',
+                        ('move_type', 'not in', ['out_invoice', 'out_refund']),
+                        ('state', '!=', 'draft')
                     ]}"
                 />
             </xpath>


### PR DESCRIPTION
The "Regenerate agents" button was not hidden properly. It was still visible on posted invoices or in supplier invoices.
xml states and attrs invisible are combined with AND operator which was not correct in this case, we need OR.