### PR TITLE
[16.0][FIX] account_commission: Regenerate agents button invisibility

### DIFF
--- a/account_commission/views/account_move_views.xml
+++ b/account_commission/views/account_move_views.xml
@@ -89,9 +89,10 @@
                     name="recompute_lines_agents"
                     type="object"
                     string="Regenerate agents"
-                    states="draft"
                     attrs="{'invisible': [
-                        ('move_type', 'not in', ['out_invoice', 'out_refund'])
+                        '|',
+                        ('move_type', 'not in', ['out_invoice', 'out_refund']),
+                        ('state', '!=', 'draft')
                     ]}"
                 />
             </xpath>


### PR DESCRIPTION
- xml states and attrs invisible are combined with AND operator which was not correct in this case, we need OR.