### PR TITLE
[14.0][FIX] sale_commission: Regenerate agents button invisibility

### DIFF
--- a/sale_commission/views/account_move_views.xml
+++ b/sale_commission/views/account_move_views.xml
@@ -70,9 +70,10 @@
                     name="recompute_lines_agents"
                     type="object"
                     string="Regenerate agents"
-                    states="draft"
                     attrs="{'invisible': [
-                        ('move_type', 'not in', ['out_invoice', 'out_refund'])
+                        '|',
+                        ('move_type', 'not in', ['out_invoice', 'out_refund']),
+                        ('state', '!=', 'draft')
                     ]}"
                 />
             </xpath>


### PR DESCRIPTION
- xml states and attrs invisible are combined with AND operator which was not correct in this case, we need OR.