### PR TITLE
[14.0][ADD] sale_commission_product_criteria

### DIFF
--- a/sale_commission_product_criteria/__init__.py
+++ b/sale_commission_product_criteria/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_commission_product_criteria/__manifest__.py
+++ b/sale_commission_product_criteria/__manifest__.py
@@ -1,0 +1,21 @@
+# © 2023 ooops404
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+{
+    "name": "Sale Commission Product Criteria",
+    "summary": "Advanced commissions rules",
+    "version": "14.0.1.0.1",
+    "author": "Ilyas, Ooops404, Odoo Community Association (OCA)",
+    "maintainers": ["ilyasProgrammer"],
+    "website": "https://github.com/OCA/commission",
+    "category": "Sales Management",
+    "license": "AGPL-3",
+    "depends": ["sale_commission", "web_domain_field"],
+    "data": [
+        "views/views.xml",
+        "security/ir.model.access.csv",
+    ],
+    "demo": ["demo/sale_agent_demo.xml"],
+    "application": False,
+    "installable": True,
+    "auto_install": False,
+}

--- a/sale_commission_product_criteria/demo/sale_agent_demo.xml
+++ b/sale_commission_product_criteria/demo/sale_agent_demo.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" ?>
+<odoo>
+
+    <record id="demo_commission_rules" model="sale.commission">
+        <field name="name">Based on Rules</field>
+        <field name="commission_type">product</field>
+    </record>
+
+    <record id="demo_commission_rules_item_1" model="commission.item">
+        <field name="commission_id" ref="demo_commission_rules" />
+        <field name="sequence" eval="1" />
+        <field name="based_on">sol</field>
+        <field name="applied_on">3_global</field>
+        <field name="commission_type">fixed</field>
+        <field name="fixed_amount">10</field>
+    </record>
+
+    <record id="demo_commission_rules_item_2" model="commission.item">
+        <field name="commission_id" ref="demo_commission_rules" />
+        <field name="sequence" eval="2" />
+        <field name="based_on">sol</field>
+        <field name="applied_on">2_product_category</field>
+        <field name="commission_type">fixed</field>
+        <field name="fixed_amount">20</field>
+        <field name="categ_id" ref="product.product_category_5" />
+    </record>
+
+    <record id="demo_commission_rules_item_3" model="commission.item">
+        <field name="commission_id" ref="demo_commission_rules" />
+        <field name="sequence" eval="3" />
+        <field name="based_on">sol</field>
+        <field name="applied_on">1_product</field>
+        <field name="commission_type">percentage</field>
+        <field name="percent_amount">5</field>
+        <field
+            name="product_tmpl_id"
+            ref="product.product_product_4_product_template"
+        />
+    </record>
+
+    <record id="demo_commission_rules_item_4" model="commission.item">
+        <field name="commission_id" ref="demo_commission_rules" />
+        <field name="sequence" eval="4" />
+        <field name="based_on">sol</field>
+        <field name="applied_on">0_product_variant</field>
+        <field name="commission_type">percentage</field>
+        <field name="percent_amount">15</field>
+        <field name="product_id" ref="product.product_product_4" />
+    </record>
+
+    <record id="demo_agent_rules" model="res.partner">
+        <field name="name">Agent Rules</field>
+        <field name="is_company">True</field>
+        <field name="agent">True</field>
+        <field name="commission_id" ref="demo_commission_rules" />
+    </record>
+
+    <record id="base.res_partner_12" model="res.partner">
+        <field
+            name="agent_ids"
+            eval="[(6, 0, [ref('sale_commission_product_criteria.demo_agent_rules')])]"
+        />
+    </record>
+
+</odoo>

--- a/sale_commission_product_criteria/models/__init__.py
+++ b/sale_commission_product_criteria/models/__init__.py
@@ -1,0 +1,5 @@
+from . import sale_commission_line_mixin
+from . import commission
+from . import sale
+from . import account_move
+from . import settlement

--- a/sale_commission_product_criteria/models/account_move.py
+++ b/sale_commission_product_criteria/models/account_move.py
@@ -1,0 +1,27 @@
+# © 2023 ooops404
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+from odoo import api, fields, models
+
+
+class AccountInvoiceLineAgent(models.Model):
+    _inherit = "account.invoice.line.agent"
+
+    applied_commission_item_id = fields.Many2one("commission.item")
+
+    @api.depends(
+        "object_id.price_subtotal",
+        "object_id.product_id.commission_free",
+        "commission_id",
+    )
+    def _compute_amount(self):
+        for line in self:
+            if line.commission_id and line.commission_id.commission_type == "product":
+                inv_line = line.object_id
+                line.amount = line._get_single_commission_amount(
+                    line.commission_id,
+                    inv_line.price_subtotal,
+                    inv_line.product_id,
+                    inv_line.quantity,
+                )
+            else:
+                super(AccountInvoiceLineAgent, line)._compute_amount()

--- a/sale_commission_product_criteria/models/commission.py
+++ b/sale_commission_product_criteria/models/commission.py
@@ -1,0 +1,267 @@
+# © 2023 ooops404
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.tools import float_repr
+
+
+class SaleCommission(models.Model):
+    _inherit = "sale.commission"
+
+    commission_type = fields.Selection(
+        selection_add=[("product", "Product criteria")],
+        ondelete={"product": "set default"},
+    )
+    item_ids = fields.One2many("commission.item", "commission_id", copy=True)
+
+    def action_unarchive(self):
+        res = super().action_unarchive()
+        items = (
+            self.env["commission.item"]
+            .with_context(active_test=False)
+            .search([("commission_id", "=", self.id)])
+        )
+        if items:
+            items.write({"active": True})
+        return res
+
+    @api.onchange("commission_type")
+    def onchange_commission_type(self):
+        # Prevent commission_type change in certain cases
+        self.check_type_change_allowed_sale()
+        self.check_type_change_allowed_moves()
+
+    def check_type_change_allowed_sale(self):
+        sola_ids = self.env["sale.order.line.agent"].search(
+            [("commission_id", "=", self._origin.id)]
+        )
+        done_so_ids = sola_ids.filtered(lambda x: x.object_id.state in ["done", "sale"])
+        if done_so_ids:
+            raise ValidationError(
+                _(
+                    "There is done Sale Orders with this commission. "
+                    "Commission type change is not allowed."
+                )
+            )
+
+    def check_type_change_allowed_moves(self):
+        aila_ids = self.env["account.invoice.line.agent"].search(
+            [("commission_id", "=", self._origin.id)]
+        )
+        done_move_ids = aila_ids.filtered(
+            lambda x: x.object_id.parent_state == "posted"
+        )
+        if done_move_ids:
+            raise ValidationError(
+                _(
+                    "There is posted Account Move Lines with this commission. "
+                    "Commission type change is not allowed."
+                )
+            )
+
+
+class CommissionItem(models.Model):
+    _name = "commission.item"
+    _description = "Commission Item"
+    _order = "applied_on, based_on, categ_id desc, id desc"
+
+    sequence = fields.Integer(default=10)
+    active = fields.Boolean(default=True)
+    commission_id = fields.Many2one(
+        "sale.commission",
+        string="Commission Type",
+        domain=[("commission_type", "=", "product")],
+        required=True,
+    )
+    use_pricelist = fields.Boolean()
+    pricelist_id = fields.Many2one("product.pricelist")
+    product_tmpl_id = fields.Many2one(
+        "product.template",
+        "Product",
+        ondelete="cascade",
+        check_company=True,
+        help="Specify a template if this rule only applies to one "
+        "product template. Keep empty otherwise.",
+    )
+    product_id = fields.Many2one(
+        "product.product",
+        "Product Variant",
+        ondelete="cascade",
+        check_company=True,
+        help="Specify a product if this rule only applies "
+        "to one product. Keep empty otherwise.",
+    )
+    categ_id = fields.Many2one(
+        "product.category",
+        "Product Category",
+        ondelete="cascade",
+        help="Specify a product category if this rule only applies to "
+        "products belonging to this category or its children categories. "
+        "Keep empty otherwise.",
+    )
+    based_on = fields.Selection(
+        [("sol", "Any Sale Order Line")],
+        string="Based On",
+        required=True,
+        default="sol",
+    )
+    applied_on = fields.Selection(
+        [
+            ("3_global", "All Products"),
+            ("2_product_category", "Product Category"),
+            ("1_product", "Product"),
+            ("0_product_variant", "Product Variant"),
+        ],
+        "Apply On",
+        default="3_global",
+        required=True,
+        help="Commission Item applicable on selected option",
+    )
+    commission_type = fields.Selection(
+        [("fixed", "Fixed"), ("percentage", "Percentage")],
+        index=True,
+        default="fixed",
+        required=True,
+    )
+    fixed_amount = fields.Float("Fixed Amount", digits="Product Price")
+    percent_amount = fields.Float("Percentage Amount")
+    company_id = fields.Many2one(
+        "res.company",
+        "Company",
+        default=lambda self: self.env.company,
+        readonly=True,
+    )
+    currency_id = fields.Many2one(
+        "res.currency",
+        related="company_id.currency_id",
+        readonly=True,
+    )
+    name = fields.Char(
+        "Name",
+        compute="_compute_commission_item_name_value",
+        help="Explicit rule name for this commission line.",
+    )
+    commission_value = fields.Char(
+        "Value",
+        compute="_compute_commission_item_name_value",
+    )
+
+    @api.depends(
+        "applied_on",
+        "categ_id",
+        "product_tmpl_id",
+        "product_id",
+        "commission_type",
+        "fixed_amount",
+        "percent_amount",
+    )
+    def _compute_commission_item_name_value(self):
+        for item in self:
+            if item.categ_id and item.applied_on == "2_product_category":
+                item.name = _("Category: %s") % (item.categ_id.display_name)
+            elif item.product_tmpl_id and item.applied_on == "1_product":
+                item.name = _("Product: %s") % (item.product_tmpl_id.display_name)
+            elif item.product_id and item.applied_on == "0_product_variant":
+                item.name = _("Variant: %s") % (
+                    item.product_id.with_context(
+                        display_default_code=False
+                    ).display_name
+                )
+            else:
+                item.name = _("All Products")
+
+            if item.commission_type == "fixed":
+                decimal_places = self.env["decimal.precision"].precision_get(
+                    "Product Price"
+                )
+                if item.currency_id.position == "after":
+                    item.commission_value = "%s %s" % (
+                        float_repr(
+                            item.fixed_amount,
+                            decimal_places,
+                        ),
+                        item.currency_id.symbol or "",
+                    )
+                else:
+                    item.commission_value = "%s %s" % (
+                        item.currency_id.symbol or "",
+                        float_repr(
+                            item.fixed_amount,
+                            decimal_places,
+                        ),
+                    )
+            elif item.commission_type == "percentage":
+                item.commission_value = str(item.percent_amount) + " %"
+
+    @api.constrains("product_id", "product_tmpl_id", "categ_id")
+    def _check_product_consistency(self):
+        for item in self:
+            if item.applied_on == "2_product_category" and not item.categ_id:
+                raise ValidationError(
+                    _(
+                        "Please specify the category for which this rule should "
+                        "be applied"
+                    )
+                )
+            elif item.applied_on == "1_product" and not item.product_tmpl_id:
+                raise ValidationError(
+                    _(
+                        "Please specify the product for which this rule should "
+                        "be applied"
+                    )
+                )
+            elif item.applied_on == "0_product_variant" and not item.product_id:
+                raise ValidationError(
+                    _(
+                        "Please specify the product variant for "
+                        "which this rule should be applied"
+                    )
+                )
+
+    @api.onchange("product_id")
+    def _onchange_product_id(self):
+        has_product_id = self.filtered("product_id")
+        for item in has_product_id:
+            item.product_tmpl_id = item.product_id.product_tmpl_id
+        if self.env.context.get("default_applied_on", False) == "1_product":
+            # If a product variant is specified, apply on variants instead
+            # Reset if product variant is removed
+            has_product_id.update({"applied_on": "0_product_variant"})
+            (self - has_product_id).update({"applied_on": "1_product"})
+
+    @api.onchange("product_tmpl_id")
+    def _onchange_product_tmpl_id(self):
+        has_tmpl_id = self.filtered("product_tmpl_id")
+        for item in has_tmpl_id:
+            if (
+                item.product_id
+                and item.product_id.product_tmpl_id != item.product_tmpl_id
+            ):
+                item.product_id = None
+
+    @api.model
+    def create(self, values):
+        values = self.validate_values(values)
+        return super(CommissionItem, self).create(values)
+
+    def write(self, values):
+        values = self.validate_values(values)
+        res = super(CommissionItem, self).write(values)
+        self.invalidate_cache()
+        return res
+
+    def validate_values(self, values):
+        if values.get("applied_on", False):
+            # Ensure item consistency for later searches.
+            applied_on = values["applied_on"]
+            if applied_on == "3_global":
+                values.update(
+                    dict(product_id=None, product_tmpl_id=None, categ_id=None)
+                )
+            elif applied_on == "2_product_category":
+                values.update(dict(product_id=None, product_tmpl_id=None))
+            elif applied_on == "1_product":
+                values.update(dict(product_id=None, categ_id=None))
+            elif applied_on == "0_product_variant":
+                values.update(dict(categ_id=None))
+        return values

--- a/sale_commission_product_criteria/models/sale.py
+++ b/sale_commission_product_criteria/models/sale.py
@@ -1,0 +1,52 @@
+# © 2023 ooops404
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+from odoo import api, fields, models
+
+
+class SaleOrderLineAgent(models.Model):
+    _inherit = "sale.order.line.agent"
+
+    discount = fields.Float(related="object_id.discount")
+    applied_commission_item_id = fields.Many2one("commission.item")
+    based_on = fields.Selection(related="applied_commission_item_id.based_on")
+    applied_on_name = fields.Char(related="applied_commission_item_id.name")
+    commission_type = fields.Selection(
+        related="applied_commission_item_id.commission_type"
+    )
+    fixed_amount = fields.Float(related="applied_commission_item_id.fixed_amount")
+    percent_amount = fields.Float(related="applied_commission_item_id.percent_amount")
+
+    @api.depends(
+        "object_id.price_subtotal", "object_id.product_id", "object_id.product_uom_qty"
+    )
+    def _compute_amount(self):
+        for line in self:
+            if line.commission_id and line.commission_id.commission_type == "product":
+                order_line = line.object_id
+                line.amount = line._get_single_commission_amount(
+                    line.commission_id,
+                    order_line.price_subtotal,
+                    order_line.product_id,
+                    order_line.product_uom_qty,
+                )
+            else:
+                super(SaleOrderLineAgent, line)._compute_amount()
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _prepare_invoice_line(self, **optional_values):
+        vals = super()._prepare_invoice_line(**optional_values)
+        vals["agent_ids"] = [
+            (
+                0,
+                0,
+                {
+                    "agent_id": x.agent_id.id,
+                    "commission_id": x.commission_id.id,
+                },
+            )
+            for x in self.agent_ids
+        ]
+        return vals

--- a/sale_commission_product_criteria/models/sale_commission_line_mixin.py
+++ b/sale_commission_product_criteria/models/sale_commission_line_mixin.py
@@ -1,0 +1,77 @@
+# © 2023 ooops404
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+from odoo import fields, models
+
+
+class SaleCommissionLineMixin(models.AbstractModel):
+    _inherit = "sale.commission.line.mixin"
+
+    applied_commission_id = fields.Many2one("sale.commission", readonly=True)
+    commission_id = fields.Many2one(
+        comodel_name="sale.commission",
+        ondelete="restrict",
+        required=False,
+        compute="_compute_commission_id",
+        store=True,
+        readonly=False,
+        copy=True,
+    )
+
+    def _get_commission_items(self, commission, product):
+        # Method replaced
+        categ_ids = {}
+        categ = product.categ_id
+        while categ:
+            categ_ids[categ.id] = True
+            categ = categ.parent_id
+        categ_ids = list(categ_ids)
+        # Select all suitable items. Order by best match
+        # (priority is: all/cat/subcat/product/variant).
+        self.env.cr.execute(
+            """
+            SELECT
+                item.id
+            FROM
+                commission_item AS item
+            LEFT JOIN product_category AS categ ON item.categ_id = categ.id
+            WHERE
+                (item.product_tmpl_id IS NULL OR item.product_tmpl_id = any(%s))
+                AND (item.product_id IS NULL OR item.product_id = any(%s))
+                AND (item.categ_id IS NULL OR item.categ_id = any(%s))
+                AND (item.commission_id = %s)
+                AND (item.active = TRUE)
+            ORDER BY
+                item.applied_on, categ.complete_name desc, item.id desc
+            """,
+            (
+                product.product_tmpl_id.ids,
+                product.ids,
+                categ_ids,
+                commission._origin.id,  # Added this
+            ),
+        )
+        item_ids = [x[0] for x in self.env.cr.fetchall()]
+        return item_ids
+
+    def _get_single_commission_amount(self, commission, subtotal, product, quantity):
+        self.ensure_one()
+        item_ids = self._get_commission_items(commission, product)
+        if not item_ids:
+            return 0.0
+        commission_item = self.env["commission.item"].browse(item_ids[0])
+        if commission.amount_base_type == "net_amount":
+            # If subtotal (sale_price * quantity) is less than
+            # standard_price * quantity, it means that we are selling at
+            # lower price than we bought, so set amount_base to 0
+            subtotal = max([0, subtotal - product.standard_price * quantity])
+        self.applied_commission_item_id = commission_item
+        # if self.agent_id.use_multi_type_commissions:
+        self.applied_commission_id = commission_item.commission_id
+        if commission_item.commission_type == "fixed":
+            return commission_item.fixed_amount
+        elif commission_item.commission_type == "percentage":
+            return subtotal * (commission_item.percent_amount / 100.0)
+
+    def _get_discount_value(self, commission_item):
+        # Will be overridden
+        return self.object_id.discount

--- a/sale_commission_product_criteria/models/settlement.py
+++ b/sale_commission_product_criteria/models/settlement.py
@@ -1,0 +1,7 @@
+# © 2023 ooops404
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+from odoo import models
+
+
+class SettlementLine(models.Model):
+    _inherit = "sale.commission.settlement.line"

--- a/sale_commission_product_criteria/readme/CONTRIBUTORS.rst
+++ b/sale_commission_product_criteria/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Ooops404 <https://www.ooops404.com>`__:
+
+  * Ilyas <irazor147@gmail.com>

--- a/sale_commission_product_criteria/readme/DESCRIPTION.rst
+++ b/sale_commission_product_criteria/readme/DESCRIPTION.rst
@@ -1,0 +1,16 @@
+This module allows to set in the same Commission Type different commission rates according to the product on SO/invoice line.
+
+This is made possible since this module adds a new "Product criteria" type to Commission Type and applies commission rates with the same logic of sale pricelist items.
+
+For example, such a Commission Type can grant:
+
+10% on a specific Product A,
+10$ on Product B,
+4% on products in Category 1 and
+5$ on all other products.
+
+In SO/invoice, system will apply different commissions based on variant/product/category or global, applied hierarchically. This means that for the example above, if product A is assigned to Category 1, commission assigned is 10%, as per variant/product/category/global rule application order.
+
+Furthermore, these commission type items can be accessed and created by a specific menu, to facilitate their management in environments with lots of records.
+
+The form for commission type item can be extended by future modules with further conditions to decide when to apply a specific item.

--- a/sale_commission_product_criteria/readme/USAGE.rst
+++ b/sale_commission_product_criteria/readme/USAGE.rst
@@ -1,0 +1,7 @@
+To use features of this module, you need to:
+
+#. Go to Sales > Commission Management > Commission Types.
+#. Create a Commission Type with type = "Product criteria".
+#. Create multiple rules based on variant/product/category or global
+#. These rules will be sorted according to the same logic of sale pricelist.
+#. Rest flow is according to OCA sale_commission module.

--- a/sale_commission_product_criteria/security/ir.model.access.csv
+++ b/sale_commission_product_criteria/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_commission_item_manager,access_commission_item_manager,model_commission_item,sales_team.group_sale_manager,1,1,1,1

--- a/sale_commission_product_criteria/tests/__init__.py
+++ b/sale_commission_product_criteria/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_commission_product_criteria

--- a/sale_commission_product_criteria/tests/test_sale_commission_product_criteria.py
+++ b/sale_commission_product_criteria/tests/test_sale_commission_product_criteria.py
@@ -1,0 +1,200 @@
+# © 2023 ooops404
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import SavepointCase
+
+
+class TestSaleCommission(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.commission_model = cls.env["sale.commission"]
+        cls.company = cls.env.ref("base.main_company")
+        cls.res_partner_model = cls.env["res.partner"]
+        cls.partner = cls.env.ref("base.res_partner_12")
+        cls.partner2 = cls.env.ref("base.res_partner_10")
+        cls.sale_order_model = cls.env["sale.order"]
+        cls.advance_inv_model = cls.env["sale.advance.payment.inv"]
+        cls.settle_model = cls.env["sale.commission.settlement"]
+        cls.make_settle_model = cls.env["sale.commission.make.settle"]
+        cls.make_inv_model = cls.env["sale.commission.make.invoice"]
+        cls.product_1 = cls.env.ref("product.product_product_1")
+        cls.product_4 = cls.env.ref("product.product_product_4")
+        cls.product_5 = cls.env.ref("product.product_product_5")
+        cls.product_6 = cls.env.ref("product.product_product_6")
+        cls.product_1.write({"invoice_policy": "order"})
+        cls.product_4.write({"invoice_policy": "order"})
+        cls.product_5.write({"invoice_policy": "order"})
+        cls.product_6.write({"commission_free": True})
+        cls.product_template_4 = cls.env.ref(
+            "product.product_product_4_product_template"
+        )
+        cls.product_template_4.write({"invoice_policy": "order"})
+        cls.journal = cls.env["account.journal"].search(
+            [("type", "=", "purchase")], limit=1
+        )
+        cls.rules_commission_id = cls.env.ref(
+            "sale_commission_product_criteria.demo_commission_rules"
+        )
+        cls.com_item_1 = cls.env.ref(
+            "sale_commission_product_criteria.demo_commission_rules_item_1"
+        )
+        cls.com_item_2 = cls.env.ref(
+            "sale_commission_product_criteria.demo_commission_rules_item_2"
+        )
+        cls.com_item_3 = cls.env.ref(
+            "sale_commission_product_criteria.demo_commission_rules_item_3"
+        )
+        cls.com_item_4 = cls.env.ref(
+            "sale_commission_product_criteria.demo_commission_rules_item_4"
+        )
+
+    def test_sale_commission_product_criteria_items(self):
+        # items names
+        self.com_item_1._compute_commission_item_name_value()
+        self.com_item_1.currency_id.position = "after"
+        self.com_item_1._compute_commission_item_name_value()
+        self.assertEqual(self.com_item_1.name, "All Products")
+        self.com_item_1.write({"applied_on": "3_global"})
+        self.com_item_2._compute_commission_item_name_value()
+        self.assertEqual(
+            self.com_item_2.name, "Category: All / Saleable / Office Furniture"
+        )
+        self.com_item_2.write({"applied_on": "2_product_category"})
+        self.com_item_3._compute_commission_item_name_value()
+        self.assertEqual(self.com_item_3.name, "Product: Customizable Desk (CONFIG)")
+        self.com_item_3.write({"applied_on": "1_product"})
+        self.com_item_4._compute_commission_item_name_value()
+        self.assertEqual(
+            self.com_item_4.name, "Variant: Customizable Desk (CONFIG) (Steel, White)"
+        )
+        self.com_item_4.write({"applied_on": "0_product_variant"})
+
+        # 3_global
+        so_1 = self._create_sale_order(self.product_1, self.partner)
+        so_1.recompute_lines_agents()
+        self.assertEqual(so_1.partner_agent_ids.name, "Agent Rules")
+        self.assertEqual(so_1.order_line.agent_ids.amount, 10)
+        so_1.action_confirm()
+        invoice = self._invoice_sale_order(so_1)
+        invoice.recompute_lines_agents()
+        invoice.action_post()
+
+        # 2_product_category
+        so = self._create_sale_order(self.product_5, self.partner)
+        so.recompute_lines_agents()
+        self.assertEqual(so.partner_agent_ids.name, "Agent Rules")
+        self.assertEqual(so.order_line.agent_ids.amount, 20)
+        so.action_confirm()
+        invoice = self._invoice_sale_order(so)
+        invoice.recompute_lines_agents()
+
+        # 1_product 5 %
+        pp4 = self.product_template_4.product_variant_id
+        so = self._create_sale_order(pp4, self.partner)
+        so.recompute_lines_agents()
+        self.assertEqual(so.partner_agent_ids.name, "Agent Rules")
+        self.assertEqual(so.order_line.agent_ids.amount, 50)
+        so.action_confirm()
+        invoice = self._invoice_sale_order(so)
+        invoice.recompute_lines_agents()
+
+        # 0_product_variant 15 %
+        so = self._create_sale_order(self.product_4, self.partner)
+        so.recompute_lines_agents()
+        self.assertEqual(so.partner_agent_ids.name, "Agent Rules")
+        self.assertEqual(so.order_line.agent_ids.amount, 150)
+        so.action_confirm()
+        invoice = self._invoice_sale_order(so)
+        invoice.recompute_lines_agents()
+
+        # Commission free product
+        so = self._create_sale_order(self.product_6, self.partner)
+        so.recompute_lines_agents()
+
+        # Type != product
+        so = self._create_sale_order(self.product_4, self.partner2)
+        so.recompute_lines_agents()
+
+        # net amount
+        self.rules_commission_id.amount_base_type = "net_amount"
+        so = self._create_sale_order(self.product_4, self.partner)
+        so.order_line.agent_ids._compute_amount()
+
+        # archive
+        self.rules_commission_id.action_archive()
+        self.rules_commission_id.action_unarchive()
+
+        # copy
+        new_rule = self.rules_commission_id.copy()
+        self.assertEqual(len(new_rule.item_ids), len(self.rules_commission_id.item_ids))
+
+        # change commission_type
+        self.rules_commission_id.commission_type = "fixed"
+        with self.assertRaises(ValidationError):
+            self.rules_commission_id.check_type_change_allowed_moves()
+        with self.assertRaises(ValidationError):
+            self.rules_commission_id.check_type_change_allowed_sale()
+
+        # no rule found
+        self.env.ref(
+            "sale_commission_product_criteria.demo_commission_rules_item_1"
+        ).unlink()
+        so = self._create_sale_order(self.product_1, self.partner)
+        so.order_line.agent_ids._compute_amount()
+
+        # _check_product_consistency
+        with self.assertRaises(ValidationError):
+            self.com_item_2.categ_id = False
+        with self.assertRaises(ValidationError):
+            self.com_item_3.product_tmpl_id = False
+        with self.assertRaises(ValidationError):
+            self.com_item_4.product_id = False
+
+        # _onchange_product_id
+        self.com_item_4.product_id = self.product_1
+        self.com_item_4._onchange_product_id()
+        self.com_item_4.with_context(
+            default_applied_on="1_product"
+        )._onchange_product_id()
+        self.com_item_4.product_tmpl_id = self.product_template_4
+        self.com_item_4._onchange_product_id()
+        self.com_item_4.product_tmpl_id = self.product_template_4
+        with self.assertRaises(ValidationError):
+            self.com_item_4._onchange_product_tmpl_id()
+
+    def _create_sale_order(self, product, partner):
+        return self.sale_order_model.create(
+            {
+                "partner_id": partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": product.name,
+                            "product_id": product.id,
+                            "product_uom_qty": 1.0,
+                            "product_uom": product.uom_id.id,
+                            "price_unit": 1000,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def _invoice_sale_order(self, sale_order, date=None):
+        old_invoices = sale_order.invoice_ids
+        wizard = self.advance_inv_model.create({"advance_payment_method": "delivered"})
+        wizard.with_context(
+            {
+                "active_model": "sale.order",
+                "active_ids": [sale_order.id],
+                "active_id": sale_order.id,
+            }
+        ).create_invoices()
+        invoice = sale_order.invoice_ids - old_invoices
+        invoice.flush()
+        return invoice

--- a/sale_commission_product_criteria/views/views.xml
+++ b/sale_commission_product_criteria/views/views.xml
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- Modified sale_commission views -->
+    <record
+        model="ir.ui.view"
+        id="view_order_agent_form_inherit_sale_commission_product_criteria_mod"
+    >
+        <field
+            name="name"
+        >sale.agent.order.inherit.form.sale_commission_product_criteria.mod</field>
+        <field name="model">sale.order</field>
+        <field name="priority" eval="99" />
+        <field name="inherit_id" ref="sale_commission.view_order_agent_form_inherit" />
+        <field name="arch" type="xml">
+            <button name="button_edit_agents" position="replace">
+                <button
+                    name="button_edit_agents"
+                    icon="fa-users"
+                    attrs="{'invisible': [('commission_free', '=', True)]}"
+                    type="object"
+                />
+            </button>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="sale_commission_form_lines_mod">
+        <field name="name">sale.commission.form.view.inherit</field>
+        <field name="model">sale.commission</field>
+        <field name="inherit_id" ref="sale_commission.sale_commission_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='section_ids']/.." position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('commission_type', '=', 'product')]}</attribute>
+            </xpath>
+            <form position="inside">
+                <group
+                    string="Rules"
+                    name="rules_group"
+                    colspan="4"
+                    attrs="{'invisible': [('commission_type', '!=', 'product')]}"
+                >
+                    <field
+                        name="item_ids"
+                        nolabel="1"
+                        context="{'hide_commission_id':1}"
+                        colspan="4"
+                    >
+                        <tree string="Items">
+                            <field name="sequence" invisible="1" />
+                            <field name="name" string="Applied On" />
+                            <field name="commission_value" />
+                            <field name="based_on" invisible="1" />
+                        </tree>
+                    </field>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_sale_order_line_tree_mod">
+        <field name="name">sale.order.line.agent.mod</field>
+        <field name="model">sale.order.line.agent</field>
+        <field name="priority" eval="99" />
+        <field name="inherit_id" ref="sale_commission.view_sale_order_line_tree" />
+        <field name="arch" type="xml">
+            <field name="commission_id" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="amount" position="before">
+                <field name="applied_on_name" string="Applied On" invisible="1" />
+                <field name="based_on" string="Based On" invisible="1" />
+                <field name="commission_type" string="Price Type" invisible="1" />
+                <field name="fixed_amount" string="Amount (fixed)" invisible="1" />
+                <field name="percent_amount" string="Amount (%)" invisible="1" />
+                <field name="discount" string="Applied Disc. (%)" invisible="1" />
+            </field>
+            <field name="amount" position="replace">
+                <field name="applied_commission_id" invisible="1" />
+                <field name="amount" string="Final Amount" />
+            </field>
+        </field>
+    </record>
+
+    <!-- New views -->
+    <record id="commission_item_form_view" model="ir.ui.view">
+        <field name="name">commission.item.form</field>
+        <field name="model">commission.item</field>
+        <field name="arch" type="xml">
+            <form string="Commission Item">
+                <sheet>
+                    <h1>
+                        <field name="name" />
+                    </h1>
+                    <group>
+                        <group name="pricelist_rule_target">
+                            <field name="company_id" invisible="1" />
+                            <field
+                                name="commission_id"
+                                invisible="context.get('hide_commission_id')"
+                                options="{'no_create': True, 'no_open': 1}"
+                                domain="[('commission_type', '=', 'product')]"
+                            />
+                            <field name="applied_on" widget="radio" />
+                            <field name="based_on" invisible="1" />
+                            <field name="use_pricelist" invisible="1" />
+                            <field
+                                name="categ_id"
+                                attrs="{
+                                      'invisible':[('applied_on', '!=', '2_product_category')],
+                                      'required':[('applied_on', '=', '2_product_category')]}"
+                                options="{'no_create':1}"
+                            />
+                            <field
+                                name="product_tmpl_id"
+                                attrs="{
+                                        'invisible':[('applied_on', '!=', '1_product')],
+                                        'required':[('applied_on', '=', '1_product')]}"
+                                options="{'no_create':1}"
+                            />
+                            <field
+                                name="product_id"
+                                attrs="{
+                                        'invisible':[('applied_on', '!=', '0_product_variant')],
+                                        'required':[('applied_on', '=', '0_product_variant')]}"
+                                options="{'no_create':1}"
+                            />
+                        </group>
+                    </group>
+                    <group
+                        string="Commission Computation"
+                        name="commission_computation"
+                        groups="sales_team.group_sale_manager"
+                    >
+                        <group name="commission_rule_method">
+                            <field
+                                name="commission_type"
+                                string="Compute Price"
+                                widget="radio"
+                            />
+                        </group>
+                        <group name="commission_rule_base">
+                            <field
+                                name="fixed_amount"
+                                attrs="{'invisible':[('commission_type', '!=', 'fixed')]}"
+                            />
+                            <label
+                                for="percent_amount"
+                                attrs="{'invisible':[('commission_type', '!=', 'percentage')]}"
+                            />
+                            <div
+                                attrs="{'invisible':[('commission_type', '!=', 'percentage')]}"
+                            >
+                                <field
+                                    name="percent_amount"
+                                    class="oe_inline"
+                                    attrs="{'invisible':[('commission_type', '!=', 'percentage')]}"
+                                />
+                                %%
+                            </div>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="commission_item_tree_view" model="ir.ui.view">
+        <field name="name">commission.item.tree</field>
+        <field name="model">commission.item</field>
+        <field name="arch" type="xml">
+            <tree string="Commission Items">
+                <field name="commission_id" />
+                <field name="name" />
+                <field name="applied_on" optional="hide" />
+                <field name="use_pricelist" invisible="1" />
+                <field name="commission_value" />
+                <field name="based_on" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="commission_item_search" model="ir.ui.view">
+        <field name="name">commission.item.search.view</field>
+        <field name="model">commission.item</field>
+        <field name="arch" type="xml">
+            <search string="Commission Items">
+                <field name="commission_id" />
+                <group expand="0" string="Group By">
+                    <filter
+                        string="Commission"
+                        name="group_by_commission"
+                        domain="[]"
+                        context="{'group_by' : 'commission_id'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="commission_item_action" model="ir.actions.act_window">
+        <field name="name">Commission Items</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">commission.item</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">
+            {"hide_commission_id":1, 'search_default_group_by_commission': 1,}
+        </field>
+    </record>
+
+    <record id="commission_item_action_tree" model="ir.actions.act_window">
+        <field name="name">Commission Items</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">commission.item</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">
+            {"hide_commission_id":0, 'search_default_group_by_commission': 1,}
+        </field>
+        <field
+            name="view_ids"
+            eval="[(5, 0, 0),
+            (0, 0, {'view_mode': 'tree', 'view_id': ref('commission_item_tree_view')}),
+            (0, 0, {'view_mode': 'form', 'view_id': ref('commission_item_form_view')})]"
+        />
+    </record>
+
+    <menuitem
+        name="Commission Type Items"
+        id="menu_sale_commissions_items"
+        action="commission_item_action_tree"
+        parent="sale_commission.menu_sale_commissions_management"
+        groups="sales_team.group_sale_manager"
+        sequence="10"
+    />
+</odoo>

--- a/setup/sale_commission_product_criteria/odoo/addons/sale_commission_product_criteria
+++ b/setup/sale_commission_product_criteria/odoo/addons/sale_commission_product_criteria
@@ -1,0 +1,1 @@
+../../../../sale_commission_product_criteria

--- a/setup/sale_commission_product_criteria/setup.py
+++ b/setup/sale_commission_product_criteria/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module allows to set in the same Commission Type different commission rates according to the product on SO/invoice line.

This is made possible since this module adds a new "Rules" type to Commission Type and applies commission rates with the same logic of sale pricelist items.

For example, such a Commission Type can grant:

10% on a specific Product A,
10$ on Product B,
4% on products in Category 1 and
5$ on all other products.

In SO/invoice, system will apply different commissions based on variant/product/category or global, applied hierarchically. This means that for the example above, if product A is assigned to Category 1, commission assigned is 10%, as per variant/product/category/global rule application order.

Furthermore, these commission type items can be accessed and created by a specific menu, to facilitate their management in environments with lots of records.

The form for commission type item can be extended by future modules with further conditions to decide when to apply a specific item.
