### PR TITLE
[16.0][FIX] account_commission: button typo and period string

### DIFF
--- a/account_commission/i18n/account_commission.pot
+++ b/account_commission/i18n/account_commission.pot
@@ -549,7 +549,7 @@ msgstr ""
 
 #. module: account_commission
 #: model_terms:ir.ui.view,arch_db:account_commission.commission_make_invoice_form
-msgid "_Cancel"
+msgid "Cancel"
 msgstr ""
 
 #. module: account_commission

--- a/account_commission/i18n/hr.po
+++ b/account_commission/i18n/hr.po
@@ -551,7 +551,7 @@ msgstr ""
 
 #. module: account_commission
 #: model_terms:ir.ui.view,arch_db:account_commission.commission_make_invoice_form
-msgid "_Cancel"
+msgid "Cancel"
 msgstr ""
 
 #. module: account_commission

--- a/account_commission/i18n/ja.po
+++ b/account_commission/i18n/ja.po
@@ -556,8 +556,8 @@ msgstr "精算済明細を修正することはできません"
 
 #. module: account_commission
 #: model_terms:ir.ui.view,arch_db:account_commission.commission_make_invoice_form
-msgid "_Cancel"
-msgstr "_キャンセル"
+msgid "Cancel"
+msgstr "キャンセル"
 
 #. module: account_commission
 #: model_terms:ir.ui.view,arch_db:account_commission.view_invoice_commission_analysis_graph

--- a/account_commission/models/commission_settlement.py
+++ b/account_commission/models/commission_settlement.py
@@ -107,13 +107,12 @@ class CommissionSettlement(models.Model):
                         "product_id": product.id,
                         "quantity": -1 if settlement.total < 0 else 1,
                         "price_unit": abs(settlement.total),
-                        "name": (
-                            "\n"
-                            + _(
-                                "Period: from %(date_from)s to %(date_to)s",
-                                date_from=date_from.strftime(lang.date_format),
-                                date_to=date_to.strftime(lang.date_format),
-                            ),
+                        "name": product.with_context(lang=lang.code).display_name
+                        + "\n"
+                        + _(
+                            "Period: from %(date_from)s to %(date_to)s",
+                            date_from=date_from.strftime(lang.date_format),
+                            date_to=date_to.strftime(lang.date_format),
                         ),
                         # todo or compute agent currency_id?
                         "currency_id": settlement.currency_id.id,

--- a/account_commission/wizards/wizard_invoice.xml
+++ b/account_commission/wizards/wizard_invoice.xml
@@ -33,7 +33,12 @@
                         type="object"
                         class="oe_highlight"
                     />
-                    <button special="cancel" string="_Cancel" class="oe_link" />
+                    <button
+                        special="cancel"
+                        data-hotkey="z"
+                        string="Cancel"
+                        class="oe_link"
+                    />
                 </footer>
             </form>
         </field>


### PR DESCRIPTION
- cancel button string typo
- period string for invoice line name was "('\nPeriod: from 04/01/2023 to 04/30/2023',)"