### PR TITLE
[16.0][FIX] account_commission: revert settlement state to settled when deleting draft settlement invoice

### DIFF
--- a/account_commission/models/account_move.py
+++ b/account_commission/models/account_move.py
@@ -114,6 +114,13 @@ class AccountMove(models.Model):
                 res["arch"] = etree.tostring(invoice_xml)
         return res
 
+    def unlink(self):
+        """Put 'invoiced' settlements associated to the invoices back in settled state."""
+        self.invoice_line_ids.settlement_id.filtered(
+            lambda s: s.state == "invoiced"
+        ).write({"state": "settled"})
+        return super().unlink()
+
 
 class AccountMoveLine(models.Model):
     _inherit = [

--- a/account_commission/tests/test_account_commission.py
+++ b/account_commission/tests/test_account_commission.py
@@ -454,3 +454,14 @@ class TestAccountCommission(TestCommissionBase):
         settlements.make_invoices(self.journal, self.commission_product, grouped=True)
         invoices = settlements.mapped("invoice_id")
         self.assertEqual(2, invoices.settlement_count)
+
+    def test_unlink_settlement_invoice(self):
+        settlements = self._create_multi_settlements()
+        invoices = settlements.make_invoices(self.journal, self.commission_product)
+        self.assertTrue(
+            all(state == "invoiced" for state in settlements.mapped("state"))
+        )
+        invoices.unlink()
+        self.assertTrue(
+            all(state == "settled" for state in settlements.mapped("state"))
+        )


### PR DESCRIPTION
- if you delete a draft settlement invoice, the settlement is stuck on "invoiced" state