### PR TITLE
[14.0][FIX] sale_commission: Visibility of agent compute button on invoices

### DIFF
--- a/sale_commission/views/account_move_views.xml
+++ b/sale_commission/views/account_move_views.xml
@@ -70,9 +70,10 @@
                     name="recompute_lines_agents"
                     type="object"
                     string="Regenerate agents"
-                    states="draft"
                     attrs="{'invisible': [
-                        ('move_type', 'not in', ['out_invoice', 'out_refund'])
+                        '|',
+                        ('move_type', 'not in', ['out_invoice', 'out_refund']),
+                        ('state', '!=', 'draft')
                     ]}"
                 />
             </xpath>


### PR DESCRIPTION
Due to how the "states" attribute works, it's being added to the invisible domain with an AND operator, so the button was visible on supplier invoices when it shouldn't, as it does nothing.

![image](https://user-images.githubusercontent.com/47854752/233406304-f07ad404-43f3-4bc0-b997-8c31f3b7307f.png)


This affects every version and is a nice change for all, mostly saving "why is that there" headache questions

Seems like it was brought up in this ancient issue https://github.com/odoo/odoo/issues/3838, but nothing ever came of it at least functionality wise, maybe it is documented somewhere as intended behaviour but I haven't looked