### PR TITLE
[16.0][IMP] commission: Default commission_free instead of related

### DIFF
--- a/account_commission/models/account_move.py
+++ b/account_commission/models/account_move.py
@@ -206,7 +206,7 @@ class AccountInvoiceLineAgent(models.Model):
 
     @api.depends(
         "object_id.price_subtotal",
-        "object_id.product_id.commission_free",
+        "object_id.commission_free",
         "commission_id",
     )
     def _compute_amount(self):

--- a/commission/models/commission_mixin.py
+++ b/commission/models/commission_mixin.py
@@ -23,7 +23,7 @@ class CommissionMixin(models.AbstractModel):
     product_id = fields.Many2one(comodel_name="product.product", string="Product")
     commission_free = fields.Boolean(
         string="Comm. free",
-        related="product_id.commission_free",
+        compute="_compute_commission_free",
         store=True,
         readonly=True,
     )
@@ -49,6 +49,12 @@ class CommissionMixin(models.AbstractModel):
     def _compute_agent_ids(self):
         """Empty method that needs to be implemented in children models."""
         raise NotImplementedError()
+
+    @api.depends("product_id")
+    def _compute_commission_free(self):
+        """Compute instead of a simple related to have a proper initialized value."""
+        for line in self:
+            line.commission_free = line.product_id.commission_free
 
     @api.depends("commission_free", "agent_ids")
     def _compute_commission_status(self):


### PR DESCRIPTION
Error case:
- Do normal settlement process for any product (sell it, invoice it, settle it)
- Change "Free of commission" on that same product
![image](https://user-images.githubusercontent.com/47854752/234566914-9de45d11-e7b1-44a2-9b81-d2bdfe4895d9.png)

This is because it triggers computes through depends, reaching [this line](https://github.com/OCA/commission/blob/15.0/account_commission/models/account_move.py#L151) which causes the error (which is arguably probably suboptimal, but besides the point I think)

To me logically, old sale and invoice lines with commissions shouldn't be touched if product is no longer commissionable. I imagine this is what the `store=True` part of the related line level field `commission_free` is for, but it still changes the value if changes on the product.
To fix this I changed the `related` to a default value instead, this way it wouldn't change if the product is changed in the future. No data is lost since the previous field was already stored

Also changed the depends to the product directly in account_commission so it would use the line's field, making things more cohesive