### PR TITLE
[14.0][ADD] sale_commission_product_criteria_discount

### DIFF
--- a/sale_commission_product_criteria_discount/__init__.py
+++ b/sale_commission_product_criteria_discount/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_commission_product_criteria_discount/__manifest__.py
+++ b/sale_commission_product_criteria_discount/__manifest__.py
@@ -1,0 +1,23 @@
+# © 2023 ooops404
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+{
+    "name": "Sale Commission Product Criteria Discount",
+    "summary": "Advanced commissions rules with discount",
+    "version": "14.0.1.0.0",
+    "author": "Ilyas," "Ooops404," "Odoo Community Association (OCA)",
+    "contributors": ["Ilyas"],
+    "maintainers": ["ilyasProgrammer"],
+    "website": "https://github.com/OCA/commission",
+    "category": "Sales Management",
+    "license": "AGPL-3",
+    "depends": ["sale_commission_product_criteria"],
+    "data": [
+        "views/views.xml",
+        "views/res_config_settings_views.xml",
+        "security/base_groups.xml",
+    ],
+    "demo": ["demo/demo_data.xml"],
+    "application": False,
+    "installable": True,
+    "auto_install": False,
+}

--- a/sale_commission_product_criteria_discount/demo/demo_data.xml
+++ b/sale_commission_product_criteria_discount/demo/demo_data.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<odoo>
+
+    <record id="demo_commission_rules_item_disc_1" model="commission.item">
+        <field
+            name="commission_id"
+            ref="sale_commission_product_criteria.demo_commission_rules"
+        />
+        <field name="sequence" eval="1" />
+        <field name="based_on">discount</field>
+        <field name="applied_on">1_product</field>
+        <field name="commission_type">fixed</field>
+        <field name="fixed_amount">7.50</field>
+        <field name="discount_from">10.01</field>
+        <field name="discount_to">100</field>
+        <field
+            name="product_tmpl_id"
+            ref="product.product_product_11_product_template"
+        />
+    </record>
+
+    <record id="demo_commission_rules_item_disc_2" model="commission.item">
+        <field
+            name="commission_id"
+            ref="sale_commission_product_criteria.demo_commission_rules"
+        />
+        <field name="sequence" eval="2" />
+        <field name="based_on">discount</field>
+        <field name="applied_on">1_product</field>
+        <field name="commission_type">fixed</field>
+        <field name="fixed_amount">15</field>
+        <field name="discount_from">0</field>
+        <field name="discount_to">10</field>
+        <field
+            name="product_tmpl_id"
+            ref="product.product_product_1_product_template"
+        />
+    </record>
+
+</odoo>

--- a/sale_commission_product_criteria_discount/models/__init__.py
+++ b/sale_commission_product_criteria_discount/models/__init__.py
@@ -1,0 +1,3 @@
+from . import commission
+from . import sale
+from . import res_config_settings

--- a/sale_commission_product_criteria_discount/models/commission.py
+++ b/sale_commission_product_criteria_discount/models/commission.py
@@ -1,0 +1,24 @@
+# © 2023 ooops404
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class CommissionItem(models.Model):
+    _inherit = "commission.item"
+    _order = "applied_on, based_on, categ_id desc, id desc, discount_from, discount_to"
+
+    based_on = fields.Selection(
+        selection_add=[("discount", "Discount")],
+        ondelete={"discount": "set default"},
+    )
+    discount_from = fields.Float("Discount From")
+    discount_to = fields.Float("Discount To")
+
+    @api.constrains("discount_from", "discount_to")
+    def _check_discounts(self):
+        if any(item.discount_from > item.discount_to for item in self):
+            raise ValidationError(
+                _("Discount From should be lower than the Discount To.")
+            )
+        return True

--- a/sale_commission_product_criteria_discount/models/res_config_settings.py
+++ b/sale_commission_product_criteria_discount/models/res_config_settings.py
@@ -1,0 +1,16 @@
+# © 2023 ooops404
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    default_based_on = fields.Selection(
+        [("sol", "Any Sale Order Line"), ("discount", "Discount")],
+        "Default Based On",
+        config_parameter="sale_commission_product_criteria.default_commission_based_on",
+        default_model="commission.item",
+        default="sol",
+        required=True,
+    )

--- a/sale_commission_product_criteria_discount/models/sale.py
+++ b/sale_commission_product_criteria_discount/models/sale.py
@@ -1,0 +1,58 @@
+# © 2023 ooops404
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+from odoo import fields, models
+
+
+class SaleOrderLineAgent(models.Model):
+    _inherit = "sale.order.line.agent"
+
+    discount_from = fields.Float(related="applied_commission_item_id.discount_from")
+    discount_to = fields.Float(related="applied_commission_item_id.discount_to")
+
+    def _get_single_commission_amount(self, commission, subtotal, product, quantity):
+        # Replaced to add pricelist condition. Original in sale.commission.line.mixin.
+        self.ensure_one()
+        if product.commission_free or not commission:
+            return 0.0
+        if commission.commission_type != "product":
+            return self._get_commission_amount(commission, subtotal, product, quantity)
+        item_ids = self._get_commission_items(commission, product)
+        if not item_ids:
+            return 0.0
+        so_id = self.object_id.order_id
+        # Check discount condition
+        commission_item = False
+        for item_id in item_ids:
+            commission_item = self.env["commission.item"].browse(item_id)
+            discount = self._get_discount_value(commission_item)
+            if commission_item.based_on != "sol":
+                if (
+                    commission_item.discount_from
+                    <= discount
+                    <= commission_item.discount_to
+                ):
+                    break  # suitable item found
+            else:
+                if (
+                    commission_item.pricelist_id
+                    and so_id.pricelist_id.id != commission_item.pricelist_id.id
+                ):
+                    commission_item = False  # unsuitable item
+                else:
+                    break  # suitable item found
+            commission_item = False
+        if not commission_item:
+            # all commission items rejected
+            return 0.0
+        if commission.amount_base_type == "net_amount":
+            # If subtotal (sale_price * quantity) is less than
+            # standard_price * quantity, it means that we are selling at
+            # lower price than we bought, so set amount_base to 0
+            subtotal = max([0, subtotal - product.standard_price * quantity])
+        self.applied_commission_item_id = commission_item
+        # if self.agent_id.use_multi_type_commissions:
+        self.applied_commission_id = commission_item.commission_id
+        if commission_item.commission_type == "fixed":
+            return commission_item.fixed_amount
+        elif commission_item.commission_type == "percentage":
+            return subtotal * (commission_item.percent_amount / 100.0)

--- a/sale_commission_product_criteria_discount/readme/CONTRIBUTORS.rst
+++ b/sale_commission_product_criteria_discount/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Ooops404 <https://www.ooops404.com>`__:
+
+  * Ilyas <irazor147@gmail.com>

--- a/sale_commission_product_criteria_discount/readme/DESCRIPTION.rst
+++ b/sale_commission_product_criteria_discount/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module extends sale_commission_product_criteria to allow user to restrict the commission granted to agent on a Sale Order Line according to the discount applied on the same line.
+
+This is useful to implement a common commission structure for agents which provides a higher commission to agents granting a lower discount to customer, decreasing the commission proportionally as discount increases.

--- a/sale_commission_product_criteria_discount/readme/USAGE.rst
+++ b/sale_commission_product_criteria_discount/readme/USAGE.rst
@@ -1,0 +1,9 @@
+Make sure "Discounts" are enabled in General Settings > Sale
+
+Go to Sales > Commission Management > Commission Type
+
+In a record of type "Product criteria", create or select a line > set field "Based on" = "Discount"
+
+Two new fields will be displayed to set the range of discount applied on Sale Order Line for which this Commission Type Item will be applicable.
+
+Note that if in a Commission Type are present two Items applied to the same object (eg: the same product or same category), the one "Based on: Discount" is applied.

--- a/sale_commission_product_criteria_discount/security/base_groups.xml
+++ b/sale_commission_product_criteria_discount/security/base_groups.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<odoo>
+
+    <record model="res.groups" id="product.group_discount_per_so_line">
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]" />
+    </record>
+
+</odoo>

--- a/sale_commission_product_criteria_discount/tests/__init__.py
+++ b/sale_commission_product_criteria_discount/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_commission_product_criteria

--- a/sale_commission_product_criteria_discount/tests/test_sale_commission_product_criteria.py
+++ b/sale_commission_product_criteria_discount/tests/test_sale_commission_product_criteria.py
@@ -1,0 +1,249 @@
+# © 2023 ooops404
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import SavepointCase
+
+
+class TestSaleCommission(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.commission_model = cls.env["sale.commission"]
+        cls.company = cls.env.ref("base.main_company")
+        cls.res_partner_model = cls.env["res.partner"]
+        cls.partner = cls.env.ref("base.res_partner_12")
+        cls.partner2 = cls.env.ref("base.res_partner_10")
+        cls.sale_order_model = cls.env["sale.order"]
+        cls.advance_inv_model = cls.env["sale.advance.payment.inv"]
+        cls.settle_model = cls.env["sale.commission.settlement"]
+        cls.make_settle_model = cls.env["sale.commission.make.settle"]
+        cls.make_inv_model = cls.env["sale.commission.make.invoice"]
+        cls.product_1 = cls.env.ref("product.product_product_1")
+        cls.product_4 = cls.env.ref("product.product_product_4")
+        cls.product_5 = cls.env.ref("product.product_product_5")
+        cls.product_6 = cls.env.ref("product.product_product_6")
+        cls.product_1.write({"invoice_policy": "order"})
+        cls.product_4.write({"invoice_policy": "order"})
+        cls.product_5.write({"invoice_policy": "order"})
+        cls.product_6.write({"commission_free": True})
+        cls.product_template_4 = cls.env.ref(
+            "product.product_product_4_product_template"
+        )
+        cls.product_template_11 = cls.env.ref(
+            "product.product_product_11_product_template"
+        )
+        cls.product_template_4.write({"invoice_policy": "order"})
+        cls.journal = cls.env["account.journal"].search(
+            [("type", "=", "purchase")], limit=1
+        )
+        cls.rules_commission_id = cls.env.ref(
+            "sale_commission_product_criteria.demo_commission_rules"
+        )
+        cls.com_item_1 = cls.env.ref(
+            "sale_commission_product_criteria.demo_commission_rules_item_1"
+        )
+        cls.com_item_2 = cls.env.ref(
+            "sale_commission_product_criteria.demo_commission_rules_item_2"
+        )
+        cls.com_item_3 = cls.env.ref(
+            "sale_commission_product_criteria.demo_commission_rules_item_3"
+        )
+        cls.com_item_4 = cls.env.ref(
+            "sale_commission_product_criteria.demo_commission_rules_item_4"
+        )
+        cls.no_rules_commission_id = cls.env["sale.commission"].create(
+            {
+                "name": "No Rules Commission",
+                "commission_type": "product",
+            }
+        )
+        cls.agent_3 = cls.env["res.partner"].create(
+            {
+                "name": "Agent Tests",
+                "agent": True,
+                "commission_id": cls.no_rules_commission_id.id,
+            }
+        )
+        cls.partner_with_agent_3 = cls.env["res.partner"].create(
+            {
+                "name": "Partner Tests",
+                "agent_ids": [(6, 0, cls.agent_3.ids)],
+            }
+        )
+
+    def test_sale_commission_product_criteria_items(self):
+        # items names
+        self.com_item_1._compute_commission_item_name_value()
+        self.com_item_1.currency_id.position = "after"
+        self.com_item_1._compute_commission_item_name_value()
+        self.assertEqual(self.com_item_1.name, "All Products")
+        self.com_item_1.write({"applied_on": "3_global"})
+        self.com_item_2._compute_commission_item_name_value()
+        self.assertEqual(
+            self.com_item_2.name, "Category: All / Saleable / Office Furniture"
+        )
+        self.com_item_2.write({"applied_on": "2_product_category"})
+        self.com_item_3._compute_commission_item_name_value()
+        self.assertEqual(self.com_item_3.name, "Product: Customizable Desk (CONFIG)")
+        self.com_item_3.write({"applied_on": "1_product"})
+        self.com_item_4._compute_commission_item_name_value()
+        self.assertEqual(
+            self.com_item_4.name, "Variant: Customizable Desk (CONFIG) (Steel, White)"
+        )
+        self.com_item_4.write({"applied_on": "0_product_variant"})
+
+        # 1_product discount 0-10
+        so_1 = self._create_sale_order(self.product_1, self.partner)
+        so_1.recompute_lines_agents()
+        self.assertEqual(so_1.partner_agent_ids.name, "Agent Rules")
+        so_1.order_line.agent_ids._compute_amount()
+        self.assertEqual(so_1.order_line.agent_ids.based_on, "discount")
+        self.assertEqual(so_1.order_line.agent_ids.amount, 15)
+        so_1.action_confirm()
+        invoice = self._invoice_sale_order(so_1)
+        invoice.recompute_lines_agents()
+        invoice.action_post()
+
+        # 1_product discount 10.1-100
+        so_1 = self._create_sale_order(
+            self.product_template_11.product_variant_id, self.partner
+        )
+        so_1.order_line.discount = 11
+        so_1.recompute_lines_agents()
+        self.assertEqual(so_1.partner_agent_ids.name, "Agent Rules")
+        so_1.order_line.agent_ids._compute_amount()
+        self.assertEqual(so_1.order_line.agent_ids.based_on, "discount")
+        self.assertEqual(so_1.order_line.agent_ids.amount, 7.5)
+
+        # 2_product_category
+        so = self._create_sale_order(self.product_5, self.partner)
+        so.recompute_lines_agents()
+        self.assertEqual(so.partner_agent_ids.name, "Agent Rules")
+        self.assertEqual(so.order_line.agent_ids.amount, 20)
+        so.action_confirm()
+        invoice = self._invoice_sale_order(so)
+        invoice.recompute_lines_agents()
+
+        # 1_product 5 %
+        pp4 = self.product_template_4.product_variant_id
+        so = self._create_sale_order(pp4, self.partner)
+        so.recompute_lines_agents()
+        self.assertEqual(so.partner_agent_ids.name, "Agent Rules")
+        self.assertEqual(so.order_line.agent_ids.amount, 50)
+        so.action_confirm()
+        invoice = self._invoice_sale_order(so)
+        invoice.recompute_lines_agents()
+
+        # 0_product_variant 15 %
+        so = self._create_sale_order(self.product_4, self.partner)
+        so.recompute_lines_agents()
+        self.assertEqual(so.partner_agent_ids.name, "Agent Rules")
+        self.assertEqual(so.order_line.agent_ids.amount, 150)
+        so.action_confirm()
+        invoice = self._invoice_sale_order(so)
+        invoice.recompute_lines_agents()
+
+        # commission free product
+        zero_commission = so_1.order_line.agent_ids._get_single_commission_amount(
+            commission=False, product=self.product_6, quantity=1, subtotal=1
+        )
+        self.assertEqual(zero_commission, 0.0)
+
+        # net amount
+        self.rules_commission_id.amount_base_type = "net_amount"
+        so = self._create_sale_order(self.product_4, self.partner)
+        so.order_line.agent_ids._compute_amount()
+
+        # change commission_type
+        self.rules_commission_id.commission_type = "fixed"
+        with self.assertRaises(ValidationError):
+            self.rules_commission_id.check_type_change_allowed_moves()
+        with self.assertRaises(ValidationError):
+            self.rules_commission_id.check_type_change_allowed_sale()
+
+        # no rule found
+        self.env.ref(
+            "sale_commission_product_criteria.demo_commission_rules_item_1"
+        ).unlink()
+        so = self._create_sale_order(self.product_1, self.partner)
+        so.order_line.agent_ids._compute_amount()
+
+        # _check_product_consistency
+        with self.assertRaises(ValidationError):
+            self.com_item_2.categ_id = False
+        with self.assertRaises(ValidationError):
+            self.com_item_3.product_tmpl_id = False
+        with self.assertRaises(ValidationError):
+            self.com_item_4.product_id = False
+
+        # _onchange_product_id
+        self.com_item_4.product_id = self.product_1
+        self.com_item_4._onchange_product_id()
+        self.com_item_4.with_context(
+            default_applied_on="1_product"
+        )._onchange_product_id()
+        self.com_item_4.product_tmpl_id = self.product_template_4
+        self.com_item_4._onchange_product_id()
+        self.com_item_4.product_tmpl_id = self.product_template_4
+        with self.assertRaises(ValidationError):
+            self.com_item_4._onchange_product_tmpl_id()
+
+        # check discount
+        with self.assertRaises(ValidationError):
+            self.com_item_1.write({"discount_from": "100", "discount_to": "10"})
+
+        # Type != product
+        self.partner2.agent_ids = self.env.ref(
+            "sale_commission.res_partner_eiffel_sale_agent"
+        )
+        demo_commission = self.env.ref("sale_commission.demo_commission")
+        self.partner2.agent_ids.commission_id = demo_commission
+        so = self._create_sale_order(self.product_4, self.partner2)
+        amount = so.order_line.agent_ids._get_single_commission_amount(
+            commission=demo_commission,
+            product=so.order_line.product_id,
+            quantity=1,
+            subtotal=1,
+        )
+        self.assertEqual(amount, 0.1)
+        # without rules
+        so = self._create_sale_order(self.product_5, self.partner_with_agent_3)
+        so.recompute_lines_agents()
+        so.order_line.agent_ids._compute_amount()
+        self.assertEqual(so.order_line.agent_ids.amount, 0.0)
+
+    def _create_sale_order(self, product, partner):
+        return self.sale_order_model.create(
+            {
+                "partner_id": partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": product.name,
+                            "product_id": product.id,
+                            "product_uom_qty": 1.0,
+                            "product_uom": product.uom_id.id,
+                            "price_unit": 1000,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def _invoice_sale_order(self, sale_order, date=None):
+        old_invoices = sale_order.invoice_ids
+        wizard = self.advance_inv_model.create({"advance_payment_method": "delivered"})
+        wizard.with_context(
+            {
+                "active_model": "sale.order",
+                "active_ids": [sale_order.id],
+                "active_id": sale_order.id,
+            }
+        ).create_invoices()
+        invoice = sale_order.invoice_ids - old_invoices
+        invoice.flush()
+        return invoice

--- a/sale_commission_product_criteria_discount/views/res_config_settings_views.xml
+++ b/sale_commission_product_criteria_discount/views/res_config_settings_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit</field>
+        <field name="model">res.config.settings</field>
+        <field name="priority" eval="10" />
+        <field name="inherit_id" ref="sale.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='sale_management']" position="inside">
+                <h2>Commissions</h2>
+                <div
+                    class="row mt16 o_settings_container"
+                    name="commissions_setting_container"
+                >
+                    <div class="col-12 col-lg-6 o_setting_box" id="default_based_on">
+                        <div class="o_setting_left_pane" />
+                        <div class="o_setting_right_pane">
+                            <label for="default_based_on" />
+                            <div class="text-muted">
+                                Default commission item based on value.
+                            </div>
+                            <field name="default_based_on" />
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_commission_product_criteria_discount/views/views.xml
+++ b/sale_commission_product_criteria_discount/views/views.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record model="ir.ui.view" id="sale_commission_form_sale_commission_type_disc">
+        <field name="name">sale.commission.form.view.inherit.disc</field>
+        <field name="model">sale.commission</field>
+        <field
+            name="inherit_id"
+            ref="sale_commission_product_criteria.sale_commission_form_lines_mod"
+        />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='item_ids']//..//tree//field[@name='based_on']"
+                position="after"
+            >
+                <field name="discount_from" />
+                <field name="discount_to" />
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_sale_order_line_tree_mod">
+        <field name="name">sale.order.line.agent.mod</field>
+        <field name="model">sale.order.line.agent</field>
+        <field
+            name="inherit_id"
+            ref="sale_commission_product_criteria.view_sale_order_line_tree_mod"
+        />
+        <field name="arch" type="xml">
+            <field name="based_on" position="after">
+                <field name="discount_from" string="Disc. From" invisible="1" />
+                <field name="discount_to" string="Disc. To" invisible="1" />
+            </field>
+        </field>
+    </record>
+
+    <record id="commission_item_form_view_inherit" model="ir.ui.view">
+        <field name="name">commission.item.form.inherit</field>
+        <field name="model">commission.item</field>
+        <field
+            name="inherit_id"
+            ref="sale_commission_product_criteria.commission_item_form_view"
+        />
+        <field name="priority">99</field>
+        <field name="arch" type="xml">
+            <field name="based_on" position="replace">
+                <field name="based_on" />
+            </field>
+            <group name="pricelist_rule_target" position="after">
+                <group
+                    string="Commission by discount"
+                    name="commission_by_discount"
+                    attrs="{'invisible': [('based_on', '!=', 'discount')]}"
+                >
+                    <field
+                        name="discount_from"
+                        attrs="{'required': [('discount_to', '>', 0)]}"
+                        string="Discount From, %"
+                    />
+                    <field
+                        name="discount_to"
+                        attrs="{'required': [('discount_from', '>',0)]}"
+                        string="Discount To, %"
+                    />
+                    <div class="text-muted" colspan="2">
+                        Please note! "Discount From" must start from decimal
+                        (e.g. 10.01).
+                        <br />
+                        Only exception is if "Discount From" is 0 (e.g. 0.00).
+                    </div>
+                </group>
+            </group>
+        </field>
+    </record>
+
+    <record id="commission_item_tree_view_inherit" model="ir.ui.view">
+        <field name="name">commission.item.tree.inherit</field>
+        <field name="model">commission.item</field>
+        <field
+            name="inherit_id"
+            ref="sale_commission_product_criteria.commission_item_tree_view"
+        />
+        <field name="arch" type="xml">
+            <field name="based_on" position="after">
+                <field name="discount_from" />
+                <field name="discount_to" />
+            </field>
+        </field>
+    </record>
+
+    <record id="sale_commission_form_lines_mod_inherit" model="ir.ui.view">
+        <field name="name">sale.commission.tree.inherit</field>
+        <field name="model">sale.commission</field>
+        <field
+            name="inherit_id"
+            ref="sale_commission_product_criteria.sale_commission_form_lines_mod"
+        />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//group[@name='rules_group']//..//tree//field[@name='based_on']"
+                position="attributes"
+            >
+                <attribute name="invisible">0</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/sale_commission_product_criteria_discount/odoo/addons/sale_commission_product_criteria_discount
+++ b/setup/sale_commission_product_criteria_discount/odoo/addons/sale_commission_product_criteria_discount
@@ -1,0 +1,1 @@
+../../../../sale_commission_product_criteria_discount

--- a/setup/sale_commission_product_criteria_discount/setup.py
+++ b/setup/sale_commission_product_criteria_discount/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module extends sale_commission_product_criteria to allow user to restrict the commission granted to agent on a Sale Order Line according to the discount applied on the same line.

This is useful to implement a common commission structure for agents which provides a higher commission to agents granting a lower discount to customer, decreasing the commission proportionally as discount increases.
