### PR TITLE
[15.0][FIX] commission: Partner form view access error

### DIFF
--- a/commission/views/res_partner_views.xml
+++ b/commission/views/res_partner_views.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="view_partner_form_agent" model="ir.ui.view">
-        <field name="name">res.partner.form.agent</field>
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="name">res.partner.form - Agents per partner</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="priority" eval="18" />
         <field name="arch" type="xml">
-            <field name="vat" position="after">
-                <field name="agent" string="Agent" />
-            </field>
             <xpath
                 expr="//page[@name='sales_purchases']//field[@name='user_id']"
                 position="after"
@@ -19,6 +16,18 @@
                     context="{'default_agent': True}"
                 />
             </xpath>
+        </field>
+    </record>
+    <record id="view_partner_form_agent" model="ir.ui.view">
+        <field name="name">res.partner.form.agent</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="groups_id" eval="[(4, ref('commission.group_commission_user'))]" />
+        <field name="priority" eval="18" />
+        <field name="arch" type="xml">
+            <field name="vat" position="after">
+                <field name="agent" string="Agent" />
+            </field>
             <page name="sales_purchases" position="after">
                 <page
                     name="agent_information"


### PR DESCRIPTION
- Have a user without commission permissions.
- Access to a partner form with such user.

You get a permission error accessing settlement lines.

For avoiding it, we protect the affected fields in a separate view with `groups` field set. On v16, this can be joined again in one view, and put the `groups` attribute per field as the new architecture needs.

@Tecnativa TT43488