### PR TITLE
[16.0] [IMP] commission: Settlement mail thread activity and report

### DIFF
--- a/account_commission/views/report_settlement_templates.xml
+++ b/account_commission/views/report_settlement_templates.xml
@@ -1,21 +1,36 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <template id="report_settlement" inherit_id="commission.report_settlement">
-        <xpath expr="//th" position="before">
-            <th>Invoice date</th>
-            <th>Invoice</th>
-            <th>Invoice line</th>
+    <template
+        id="report_settlement_document"
+        inherit_id="commission.report_settlement_document"
+    >
+        <xpath expr="//div[@id='informations']" position="inside">
+            <div class="col-auto col-3 mw-100 mb-2" t-if="o.invoice_id">
+                <strong>Settlement invoice:</strong>
+                <p t-field="o.invoice_id" />
+            </div>
         </xpath>
-        <xpath expr="//table/tbody/tr/td" position="before">
-            <td>
-                <span t-field="l.date" />
-            </td>
-            <td>
-                <span t-field="l.settlement_id.invoice_id" />
-            </td>
-            <td>
-                <span t-field="l.invoice_line_id" />
-            </td>
+        <xpath expr="//th" position="after">
+            <t t-if="o.settlement_type == 'sale_invoice'">
+                <th class="text-start">Invoice line</th>
+                <th class="text-start">Quantity</th>
+            </t>
+        </xpath>
+        <xpath expr="//table/tbody/tr/td" position="after">
+            <t t-if="o.settlement_type == 'sale_invoice'">
+                <td>
+                    <span t-field="l.invoice_line_id" />
+                </td>
+                <td>
+                    <span t-field="l.invoice_line_id.quantity" />
+                </td>
+            </t>
+        </xpath>
+        <xpath expr="//table/tfoot/tr/td" position="before">
+            <t t-if="o.settlement_type == 'sale_invoice'">
+                <td />
+                <td />
+            </t>
         </xpath>
     </template>
 </odoo>

--- a/commission/models/commission_settlement.py
+++ b/commission/models/commission_settlement.py
@@ -10,6 +10,7 @@ from odoo import api, fields, models
 class CommissionSettlement(models.Model):
     _name = "commission.settlement"
     _description = "Settlement"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
 
     name = fields.Char()
     total = fields.Float(compute="_compute_total", readonly=True, store=True)
@@ -78,6 +79,12 @@ class CommissionSettlement(models.Model):
 
     def action_cancel(self):
         self.write({"state": "cancel"})
+
+    def _message_auto_subscribe_followers(self, updated_values, subtype_ids):
+        res = super()._message_auto_subscribe_followers(updated_values, subtype_ids)
+        if updated_values.get("agent_id"):
+            res.append((updated_values["agent_id"], subtype_ids, False))
+        return res
 
 
 class SettlementLine(models.Model):

--- a/commission/reports/report_settlement_templates.xml
+++ b/commission/reports/report_settlement_templates.xml
@@ -1,61 +1,85 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+    <template id="report_settlement_document">
+        <t t-set="o" t-value="o.with_context(lang=o.agent_id.lang)" />
+        <t t-call="web.external_layout">
+            <div class="row">
+                <div class="offset-col-6 col-6" name="address">
+                    <t t-set="address">
+                        <address
+                            class="mb-0"
+                            t-field="o.agent_id"
+                            t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'
+                        />
+                    </t>
+                </div>
+            </div>
+            <div class="mt-5">
+                <div class="page">
+                    <h2>Settlement</h2>
+                    <div id="informations" class="row mt-4 mb-4">
+                        <div class="col-auto col-3 mw-100 mb-2" t-if="o.date_from">
+                            <strong>From:</strong>
+                            <p t-field="o.date_from" />
+                        </div>
+                        <div class="col-auto col-3 mw-100 mb-2" t-if="o.date_to">
+                            <strong>To:</strong>
+                            <p t-field="o.date_to" />
+                        </div>
+                    </div>
+                    <table class="table table-sm" name="invoice_line_table">
+                        <thead>
+                            <tr>
+                                <th class="text-start">Date</th>
+                                <th class="text-start">Commission</th>
+                                <th class="text-end">Amount settled</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr t-foreach="o.line_ids" t-as="l">
+                                <td>
+                                    <span t-field="l.date" />
+                                </td>
+                                <td class="text-start">
+                                    <span t-field="l.commission_id" />
+                                </td>
+                                <td class="text-end">
+                                    <span
+                                        t-field="l.settled_amount"
+                                        t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"
+                                    />
+                                </td>
+                            </tr>
+                        </tbody>
+                        <tfoot>
+                            <tr>
+                                <td />
+                                <td class="text-end">
+                                    <strong>Total</strong>
+                                </td>
+                                <td class="text-end">
+                                    <span
+                                        t-field="o.total"
+                                        t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"
+                                    />
+                                </td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
+        </t>
+    </template>
+
     <template id="report_settlement">
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
-                <t t-call="web.internal_layout">
-                    <div class="page">
-                        <div class="row mt32 mb32">
-                            <div class="col-3" t-if="o.agent_id">
-                                <strong>Agent:</strong>
-                                <p t-field="o.agent_id" />
-                            </div>
-                            <div class="col-2" t-if="o.date_from">
-                                <strong>From:</strong>
-                                <p t-field="o.date_from" />
-                            </div>
-                            <div class="col-2" t-if="o.date_to">
-                                <strong>To:</strong>
-                                <p t-field="o.date_to" />
-                            </div>
-                        </div>
-                        <table class="table table-condensed">
-                            <thead>
-                                <tr>
-                                    <th>Commission</th>
-                                    <th class="text-right">Amount settled</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr t-foreach="o.line_ids" t-as="l">
-                                    <td>
-                                        <span t-field="l.commission_id" />
-                                    </td>
-                                    <td class="text-right">
-                                        <span
-                                            t-field="l.settled_amount"
-                                            t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"
-                                        />
-                                    </td>
-                                </tr>
-                            </tbody>
-                            <tfoot>
-                                <tr>
-                                    <td colspan="4">
-                                        <strong>Total</strong>
-                                    </td>
-                                    <td class="text-right">
-                                        <span
-                                            t-field="o.total"
-                                            t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"
-                                        />
-                                    </td>
-                                </tr>
-                            </tfoot>
-                        </table>
-                    </div>
-                </t>
+                <t
+                    t-call="commission.report_settlement_document"
+                    t-lang="o.agent_id.lang"
+                />
             </t>
         </t>
     </template>
+
 </odoo>

--- a/commission/tests/test_commission.py
+++ b/commission/tests/test_commission.py
@@ -167,3 +167,10 @@ class TestCommission(TestCommissionBase):
         # Write
         partner.agent_ids = [(4, self.agent_annual.id)]
         self.assertEqual(set(child.agent_ids.ids), set(partner.agent_ids.ids))
+
+    def test_auto_subscribe_agent(self):
+        settlement = self._create_settlement(
+            self.agent_monthly, self.commission_net_paid
+        )
+        # Agent must be in the followers
+        self.assertIn(self.agent_monthly, settlement.message_partner_ids)

--- a/commission/views/commission_settlement_views.xml
+++ b/commission/views/commission_settlement_views.xml
@@ -104,6 +104,11 @@
                         </group>
                     </group>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" />
+                    <field name="activity_ids" />
+                    <field name="message_ids" />
+                </div>
             </form>
         </field>
     </record>


### PR DESCRIPTION
Add mail & activity support for Settlement

Improve the existing document report:
- external_layout instead of internal_layout
- language support
- remove the Invoice column which is related to the settlement invoice ; it might not exist and I find it strange to be next to the Invoice line column which is not related (it's the commission source). 
The report changes might be too opinionated so It's on a separate commit I could remove based on feedback.


Idea is to use settlement as a communication channel with agents, who might be external.