### PR TITLE
[16.0][FIX] sale_commission: Salesmen can see invoice from SO

### DIFF
--- a/sale_commission/security/ir.model.access.csv
+++ b/sale_commission/security/ir.model.access.csv
@@ -2,3 +2,4 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_sale_order_line_agent,access_sale_order_line_agent,model_sale_order_line_agent,sales_team.group_sale_salesman,1,1,1,1
 access_commission,access_commission,commission.model_commission,sales_team.group_sale_salesman,1,0,0,0
 access_commission_section_user,access_commission_section_user,commission.model_commission_section,sales_team.group_sale_salesman,1,0,0,0
+access_account_invoice_line_agent,access_account_invoice_line_agent,account_commission.model_account_invoice_line_agent,sales_team.group_sale_salesman,1,0,0,0


### PR DESCRIPTION
Forward-port of #436

Steps to reproduce:

- With a user with only sales permission and no invoicing one.
- Go to an invoiced sales order.
- Click on the smart-button "Invoice".

You get a permission error on `account.invoice.line.agent` model.

With this commit, we add read permission to salesmen over that object to avoid the problem. The other option would be to protect the view under the invoicing group, but it's interesting that salesmen can check its own invoices commissions.

@Tecnativa TT44083