### PR TITLE
[15.0][FIX] account_commission: redefine partner can cause issue

### DIFF
--- a/account_commission/models/commission_settlement.py
+++ b/account_commission/models/commission_settlement.py
@@ -93,7 +93,7 @@ class CommissionSettlement(models.Model):
                 line_form.quantity = -1 if settlement.total < 0 else 1
                 line_form.price_unit = abs(settlement.total)
                 # Put period string
-                partner = self.agent_id
+                partner = settlement.agent_id
                 lang = self.env["res.lang"].search(
                     [
                         (


### PR DESCRIPTION
- partner is already defined above
- self can contain multiple records with different agents if overriding [grouping criteria](https://github.com/OCA/commission/blob/da5498012a2346b8e8e3a9bc7980820e48fe81fe/account_commission/models/commission_settlement.py#L120C9-L120C35)