### PR TITLE
[14.0][IMP][FIX] sale_commission_product_criteria[_domain]: permission fixes

### DIFF
--- a/sale_commission_product_criteria/security/ir.model.access.csv
+++ b/sale_commission_product_criteria/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_commission_item_manager,access_commission_item_manager,model_commission_item,sales_team.group_sale_manager,1,1,1,1
+access_commission_item_manager,access_commission_item_manager,model_commission_item,sales_team.group_sale_salesman,1,0,0,0

--- a/sale_commission_product_criteria/security/ir.model.access.csv
+++ b/sale_commission_product_criteria/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_commission_item_manager,access_commission_item_manager,model_commission_item,sales_team.group_sale_manager,1,1,1,1
-access_commission_item_manager,access_commission_item_manager,model_commission_item,sales_team.group_sale_salesman,1,0,0,0
+access_commission_item_salesman,access_commission_item_salesman,model_commission_item,sales_team.group_sale_salesman,1,0,0,0

--- a/sale_commission_product_criteria_domain/views/views.xml
+++ b/sale_commission_product_criteria_domain/views/views.xml
@@ -5,6 +5,7 @@
         <field name="name">res.partner.form.agent.inherit</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="sale_commission.view_partner_form_agent" />
+        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]" />
         <field name="arch" type="xml">
             <field name="agent_ids" position="after">
                 <field name="apply_commission_restrictions" invisible="1" />


### PR DESCRIPTION
Small changes to fix some issues with permissions with these two modules.

For a quick test of the issue on the main branch:

- Install the contacts application if not already installed
- Login as Marc Demo
- Try to access some contacts (for example: "Agent Rules Restricted Italy")

The error is `You are not allowed to access "Commission.Item"`