### PR TITLE
[14.0] [IMP] sale_commission_geo_assign

### DIFF
--- a/sale_commission_geo_assign/README.rst
+++ b/sale_commission_geo_assign/README.rst
@@ -32,6 +32,8 @@ Configure sales agents assigning them to a specific geographical area.
 
 Then, automatically assign agents to customers, according to their geographical area.
 
+A "Do not allow update with Geo Assign" setting can be activated in partner to prevent server action from editing set agents.
+
 **Table of contents**
 
 .. contents::
@@ -49,13 +51,23 @@ For every agent, you can set Countries, States or ZIP range
 Usage
 =====
 
-Go to
+Go to Sales > Agents > open a record: in tab "Agent information", set geographic criteria.
+
+When using server action, this agent will be assigned to customers whose address match the set criteria.
+
+To assign agents, go to:
 
 Sales > Customers
 
 Select the customers you want to assign agents to and click
 
-Action > Geo assign agents
+Action > Add agents with geo assign
+
+- Activating flag "Replace existing agents" will remove agents set in partner and replace them according to geographic criteria.
+
+- Activating flag "Do not add new agents if agents are already assigned" will prevent assignation if agents are already set in partner.
+
+- Deactivating both flags will simply add agents to existing ones in partner according to geographic criteria.
 
 Bug Tracker
 ===========
@@ -79,6 +91,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * iwkse <https://ooops404.com>
+* PyTech SRL <info@pytech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_commission_geo_assign/models/res_partner.py
+++ b/sale_commission_geo_assign/models/res_partner.py
@@ -15,6 +15,8 @@ class Partner(models.Model):
     agent_zip_from = fields.Char("Zip From", help="ZIP range where this agent operates")
     agent_zip_to = fields.Char("Zip To", help="ZIP range where this agent operates")
 
+    no_geo_assign_update = fields.Boolean("Do not allow update with Geo Assign")
+
     @api.onchange("agent_country_ids")
     def onchange_countries(self):
         if self.agent_country_ids:

--- a/sale_commission_geo_assign/readme/CONTRIBUTORS.rst
+++ b/sale_commission_geo_assign/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * iwkse <https://ooops404.com>
+* PyTech SRL <info@pytech.it>

--- a/sale_commission_geo_assign/readme/DESCRIPTION.rst
+++ b/sale_commission_geo_assign/readme/DESCRIPTION.rst
@@ -1,3 +1,5 @@
 Configure sales agents assigning them to a specific geographical area.
 
 Then, automatically assign agents to customers, according to their geographical area.
+
+A "Do not allow update with Geo Assign" setting can be activated in partner to prevent server action from editing set agents.

--- a/sale_commission_geo_assign/readme/USAGE.rst
+++ b/sale_commission_geo_assign/readme/USAGE.rst
@@ -1,7 +1,17 @@
-Go to
+Go to Sales > Agents > open a record: in tab "Agent information", set geographic criteria.
+
+When using server action, this agent will be assigned to customers whose address match the set criteria.
+
+To assign agents, go to:
 
 Sales > Customers
 
 Select the customers you want to assign agents to and click
 
-Action > Geo assign agents
+Action > Add agents with geo assign
+
+- Activating flag "Replace existing agents" will remove agents set in partner and replace them according to geographic criteria.
+
+- Activating flag "Do not add new agents if agents are already assigned" will prevent assignation if agents are already set in partner.
+
+- Deactivating both flags will simply add agents to existing ones in partner according to geographic criteria.

--- a/sale_commission_geo_assign/static/description/index.html
+++ b/sale_commission_geo_assign/static/description/index.html
@@ -1,20 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils: https://docutils.sourceforge.io/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Sales commissions - Geo assignation</title>
 <style type="text/css">
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 7952 2016-07-26 18:15:59Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
 
-See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
+See http://docutils.sf.net/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
 */
 
@@ -369,38 +369,46 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:9df4c468e63ac009813dca1382eca8f5246571fd0df725d7d50f0fea44bd4a94
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Production/Stable" src="https://img.shields.io/badge/maturity-Production%2FStable-green.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/commission/tree/14.0/sale_commission_geo_assign"><img alt="OCA/commission" src="https://img.shields.io/badge/github-OCA%2Fcommission-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/commission-14-0/commission-14-0-sale_commission_geo_assign"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/commission&amp;target_branch=14.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
+<p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Production/Stable" src="https://img.shields.io/badge/maturity-Production%2FStable-green.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/OCA/commission/tree/14.0/sale_commission_geo_assign"><img alt="OCA/commission" src="https://img.shields.io/badge/github-OCA%2Fcommission-lightgray.png?logo=github" /></a> <a class="reference external" href="https://translation.odoo-community.org/projects/commission-14-0/commission-14-0-sale_commission_geo_assign"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external" href="https://runboat.odoo-community.org/builds?repo=OCA/commission&amp;target_branch=14.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>Configure sales agents assigning them to a specific geographical area.</p>
 <p>Then, automatically assign agents to customers, according to their geographical area.</p>
+<p>A “Do not allow update with Geo Assign” setting can be activated in partner to prevent server action from editing set agents.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
-<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="id1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="id2">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="configuration">
-<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<h1><a class="toc-backref" href="#id1">Configuration</a></h1>
 <p>Go to</p>
 <p>Sales &gt; Commissions Management &gt; Agents</p>
 <p>For every agent, you can set Countries, States or ZIP range</p>
 </div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
-<p>Go to</p>
+<h1><a class="toc-backref" href="#id2">Usage</a></h1>
+<p>Go to Sales &gt; Agents &gt; open a record: in tab “Agent information”, set geographic criteria.</p>
+<p>When using server action, this agent will be assigned to customers whose address match the set criteria.</p>
+<p>To assign agents, go to:</p>
 <p>Sales &gt; Customers</p>
 <p>Select the customers you want to assign agents to and click</p>
-<p>Action &gt; Geo assign agents</p>
+<p>Action &gt; Add agents with geo assign</p>
+<ul class="simple">
+<li>Activating flag “Replace existing agents” will remove agents set in partner and replace them according to geographic criteria.</li>
+<li>Activating flag “Do not add new agents if agents are already assigned” will prevent assignation if agents are already set in partner.</li>
+<li>Deactivating both flags will simply add agents to existing ones in partner according to geographic criteria.</li>
+</ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/commission/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -408,28 +416,29 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
+<h1><a class="toc-backref" href="#id4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
+<h2><a class="toc-backref" href="#id5">Authors</a></h2>
 <ul class="simple">
 <li>Agile Business Group</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
 <ul class="simple">
 <li>iwkse &lt;<a class="reference external" href="https://ooops404.com">https://ooops404.com</a>&gt;</li>
+<li>PyTech SRL &lt;<a class="reference external" href="mailto:info&#64;pytech.it">info&#64;pytech.it</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
 <p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/eLBati"><img alt="eLBati" src="https://github.com/eLBati.png?size=40px" /></a></p>
+<p><a class="reference external" href="https://github.com/eLBati"><img alt="eLBati" src="https://github.com/eLBati.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/commission/tree/14.0/sale_commission_geo_assign">OCA/commission</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/sale_commission_geo_assign/views/res_partner_view.xml
+++ b/sale_commission_geo_assign/views/res_partner_view.xml
@@ -5,23 +5,26 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="sale_commission.view_partner_form_agent" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//page[@name='agent_information']/group[1]/group[2]"
-                position="after"
-            >
-                <newline />
-                <group>
-                    <field name="agent_country_ids" widget="many2many_tags" />
-                    <field name="agent_state_ids" widget="many2many_tags" />
-                </group>
-                <newline />
-                <group>
-                    <field name="agent_zip_from" />
-                </group>
-                <group>
-                    <field name="agent_zip_to" />
+            <xpath expr="//page[@name='agent_information']" position="inside">
+                <group name="agent_geo_assign" string="Geo-assign to customers">
+                    <group>
+                        <field name="agent_country_ids" widget="many2many_tags" />
+                        <field name="agent_state_ids" widget="many2many_tags" />
+                    </group>
+                    <newline />
+                    <group>
+                        <field name="agent_zip_from" />
+                    </group>
+                    <group>
+                        <field name="agent_zip_to" />
+                    </group>
                 </group>
             </xpath>
+            <page name="sales_purchases" position="inside">
+                <group>
+                    <field name="no_geo_assign_update" />
+                </group>
+            </page>
         </field>
     </record>
 

--- a/sale_commission_geo_assign/wizard/wizard_geo_assign_partner.py
+++ b/sale_commission_geo_assign/wizard/wizard_geo_assign_partner.py
@@ -5,13 +5,19 @@ from odoo.exceptions import UserError
 
 class WizardGeoAssign(models.TransientModel):
     _name = "wizard.geo.assign.partner"
+    _description = "Wizard Geo Assign Partner"
 
     check_existing_agents = fields.Boolean(
-        "Check existing agents",
+        string="Check Existing Agents",
         help="If checked, partners with already assigned agents will be "
         "blocked. Otherwise, found agents will be added",
         default=True,
     )
+    replace_existing_agents = fields.Boolean(string="Replace Existing Agents")
+
+    @api.onchange("replace_existing_agents")
+    def _onchange_replace_existing_agents(self):
+        self.check_existing_agents = not self.replace_existing_agents
 
     def geo_assign_partner(self):
         self.ensure_one()
@@ -21,13 +27,25 @@ class WizardGeoAssign(models.TransientModel):
             raise UserError(_("No agents found in the system"))
         partners = partner_model.browse(self.env.context.get("active_ids"))
         for partner in partners:
+            if partner.no_geo_assign_update:
+                raise UserError(
+                    _("Partner %s is not allowed to be updated through geo assignation")
+                    % partner.display_name
+                )
             if len(partner.agent_ids) > 0 and self.check_existing_agents:
                 raise UserError(
                     _(
                         "Partner %s already has agents. You should remove them"
-                        " or deselect 'Check existing agents'"
+                        " or deselect 'Do not add new agents if agents are already assigned'"
                     )
                     % partner.display_name
+                )
+
+            if self.replace_existing_agents:
+                partner.write(
+                    {
+                        "agent_ids": [(5, 0, 0)],
+                    }
                 )
             for agent in agents:
                 self.update_partner_data(partner, agent)

--- a/sale_commission_geo_assign/wizard/wizard_geo_assign_partner_view.xml
+++ b/sale_commission_geo_assign/wizard/wizard_geo_assign_partner_view.xml
@@ -2,7 +2,7 @@
 <odoo>
   <!-- wizard action on res.partner -->
   <record id="action_geo_assign_partner" model="ir.actions.act_window">
-    <field name="name">Geo assign agents</field>
+    <field name="name">Add Agents with Geo Assign</field>
     <field name="res_model">wizard.geo.assign.partner</field>
     <field name="view_mode">form</field>
     <field name="target">new</field>
@@ -11,12 +11,18 @@
 
   <!-- wizard view -->
   <record id="wizard_geo_assign_partner_view" model="ir.ui.view">
-      <field name="name">Geo assign agents</field>
+      <field name="name">Add Agents with Geo Assign</field>
       <field name="model">wizard.geo.assign.partner</field>
       <field name="arch" type="xml">
-          <form string="Geo assign agents">
+          <form>
               <group>
-                  <field name="check_existing_agents" />
+                  <field name="replace_existing_agents" />
+                  <separator />
+                  <field
+                        name="check_existing_agents"
+                        string="Do not add new agents if agents are already assigned"
+                        attrs="{'invisible':[('replace_existing_agents', '=', True)]}"
+                    />
               </group>
               <footer>
                   <button


### PR DESCRIPTION
This PR aims to improve some little things in `sale_commission_geo_assign`.

With the current situation it's not really helpful in a situation like: "Agent A has stopped working with our company, so Agent B must be assigned to Agent A's former customers"

To address those things there are several improvements:

- Name of the action more clear.
- New boolean in the wizard to ask if the user wants to overwrite or add agents.
- New boolean in customer to protect him from being updated by the wizard