### PR TITLE
[FIX] sale_commission_agent_restrict: agent can create res.partner

### DIFF
--- a/sale_commission_agent_restrict/models/res_partner.py
+++ b/sale_commission_agent_restrict/models/res_partner.py
@@ -34,13 +34,21 @@ class ResPartner(models.Model):
     @api.model
     def check_agent_changing_payment_terms(self, vals):
         if self.env.user.partner_id.agent:
-            if (
-                "property_payment_term_id" in vals
-                or "property_supplier_payment_term_id" in vals
-            ):
-                raise UserError(
-                    _("Agents are not allowed to change Contacts' payment terms")
-                )
+            forbidden_fields = [
+                "property_payment_term_id",
+                "property_supplier_payment_term_id",
+            ]
+            # if self is an empty recordset, we're in a create
+            is_create = not self
+            for field in forbidden_fields:
+                # allow empty value in a create
+                # workaround for form filling this field automatically
+                if is_create and not vals.get(field):
+                    continue
+                if field in vals:
+                    raise UserError(
+                        _("Agents are not allowed to change Contacts' payment terms")
+                    )
 
     @api.model
     def check_agent_changing_agents(self, vals):

--- a/sale_commission_agent_restrict/tests/test_sale_commission_agent_restrict.py
+++ b/sale_commission_agent_restrict/tests/test_sale_commission_agent_restrict.py
@@ -19,6 +19,9 @@ class TestsaleCommissionAgentRestrict(SavepointCase):
         cls.group_own_commissions = cls.env.ref(
             "sale_commission_agent_restrict.group_agent_own_commissions"
         )
+        cls.payment_term_immediate = cls.env.ref(
+            "account.account_payment_term_immediate"
+        )
         cls.user_agent = cls.users_model.create(
             {
                 "name": "John",
@@ -135,16 +138,20 @@ class TestsaleCommissionAgentRestrict(SavepointCase):
             self.partner_model.with_user(self.user_agent).create(
                 {
                     "name": "Test partner 2",
-                    "property_payment_term_id": False,
+                    "property_payment_term_id": self.payment_term_immediate.id,
                 }
             )
         with self.assertRaises(UserError):
             self.partner_model.with_user(self.user_agent).create(
                 {
                     "name": "Test partner 3",
-                    "property_supplier_payment_term_id": False,
+                    "property_supplier_payment_term_id": self.payment_term_immediate.id,
                 }
             )
+        # but can otherwise create a partner
+        f = Form(self.partner_model)
+        f.name = "Test partner 4"
+        f.save()
 
     def test_agent_cannot_see_followers(self):
         self.partner_agent.agent_ids = [(6, 0, self.user_agent.partner_id.ids)]


### PR DESCRIPTION
Quick fix for a bug that meant an agent could not create any contact because the form would pre-populate the value of payment terms.