### PR TITLE
[14,0] [FIX] sale_commission_geo_assign_product_domain: dynamic group assignment to customer's agent lines

### DIFF
--- a/sale_commission_geo_assign_product_domain/wizards/wizard_geo_assign_partner.py
+++ b/sale_commission_geo_assign_product_domain/wizards/wizard_geo_assign_partner.py
@@ -13,21 +13,30 @@ class WizardGeoAssign(models.TransientModel):
             for line in agent.commission_geo_group_ids:
                 if line.is_assignable(partner):
                     partner.agent_ids = [(4, agent.id)]
-                    partner.commission_item_agent_ids = [
-                        (
-                            0,
-                            0,
-                            {
-                                "agent_id": agent.id,
-                                "group_ids": [
-                                    (
-                                        6,
-                                        0,
-                                        line.mapped("commission_group_ids.id"),
-                                    )
-                                ],
-                            },
-                        )
-                    ]
+
+                    commission_item = partner.commission_item_agent_ids.filtered(
+                        lambda x: x.agent_id == agent
+                    )
+                    if commission_item:
+                        commission_item.group_ids = [
+                            (4, x) for x in line.mapped("commission_group_ids.id")
+                        ]
+                    else:
+                        partner.commission_item_agent_ids = [
+                            (
+                                0,
+                                0,
+                                {
+                                    "agent_id": agent.id,
+                                    "group_ids": [
+                                        (
+                                            6,
+                                            0,
+                                            line.mapped("commission_group_ids.id"),
+                                        )
+                                    ],
+                                },
+                            )
+                        ]
         else:
             super().update_partner_data(partner, agent)


### PR DESCRIPTION
Manage dynamically group assignment to customer's agent lines, before this fix you weren't able to assign two groups of the same agent, based on different rules, to the same customer.