### PR TITLE
 [16.0][FIX] account_commission: No skip reversed invoices in settlements

### DIFF
--- a/account_commission/models/account_move.py
+++ b/account_commission/models/account_move.py
@@ -264,5 +264,5 @@ class AccountInvoiceLineAgent(models.Model):
         self.ensure_one()
         return (
             self.commission_id.invoice_state == "paid"
-            and self.invoice_id.payment_state not in ["in_payment", "paid"]
+            and self.invoice_id.payment_state not in ["in_payment", "paid", "reversed"]
         ) or self.invoice_id.state != "posted"


### PR DESCRIPTION
Hi,

If invoice reach 'reversed' value in payment_state and settlements are executed when invoice is paid, it doesn't appear in the settlement. Then, we could be settle the refund invoice and not the original invoice because is marked as reversed not paid.

Regards