### PR TITLE
[15.0][FIX] account_commission: mandatory fields cannot be set to False.

### DIFF
--- a/account_commission/models/account_move.py
+++ b/account_commission/models/account_move.py
@@ -152,16 +152,6 @@ class AccountMoveLine(models.Model):
 
     @api.depends("move_id.partner_id")
     def _compute_agent_ids(self):
-        for res in self:
-            settlement_lines = self.env["commission.settlement.line"].search(
-                [("invoice_line_id", "=", res.id)]
-            )
-            for line in settlement_lines:
-                line.date = False
-                line.agent_id = False
-                line.settled_amount = 0.00
-                line.currency_id = False
-                line.commission_id = False
         self.agent_ids = False  # for resetting previous agents
         for record in self._filter_commission_applicable_lines():
             if not record.commission_free and record.product_id:


### PR DESCRIPTION
In the _compute_agent_ids function, two mandatory fields are set to False: `date` and `commission_id`.
https://github.com/OCA/commission/blob/c25ef03f47f12b3d34e6454eaae3f8cc3b19adbc/account_commission/models/account_move.py#L156-L164

An example to reproduce the error is:

1. Generate a sale and establish a customer that has a salesperson set up.
2. Add one or more products
3. Validate sale
4. Generate invoice
5. Validate and pay invoice
6. On the other hand from the commissions module we will go to the 'Settle Commissions' menu and we will set: 
> Up to'= current_date
> Settlement Type' = 'Sales invoice'.
> Add the Agent and click on 'Make settlements'.

7. Back to the invoice -> set it to draft. 
8. Change the customer and click on Save. 

We will see the following error:

![Captura desde 2023-11-21 17-48-08](https://github.com/OCA/commission/assets/101106685/43a246ac-da25-4f22-b299-8f40750793a4)


In this fix the mandatory fields are removed.