### PR TITLE
[16.0][FIX] account_commission: mandatory fields cannot be set to False.

### DIFF
--- a/account_commission/models/account_move.py
+++ b/account_commission/models/account_move.py
@@ -145,16 +145,6 @@ class AccountMoveLine(models.Model):
 
     @api.depends("move_id.partner_id")
     def _compute_agent_ids(self):
-        for res in self:
-            settlement_lines = self.env["commission.settlement.line"].search(
-                [("invoice_line_id", "=", res.id)]
-            )
-            for line in settlement_lines:
-                line.date = False
-                line.agent_id = False
-                line.settled_amount = 0.00
-                line.currency_id = False
-                line.commission_id = False
         self.agent_ids = False  # for resetting previous agents
         for record in self:
             if (


### PR DESCRIPTION
Same FIX that in v15.0 https://github.com/OCA/commission/pull/476