### PR TITLE
[fix] [sale_commision] fix search  field partner_agent_ids on multi company

### DIFF
--- a/sale_commission/models/sale_order.py
+++ b/sale_commission/models/sale_order.py
@@ -34,8 +34,16 @@ class SaleOrder(models.Model):
 
     @api.model
     def _search_agents(self, operator, value):
+
+        # Note: we need add in the domain company_id to allow retrieve only
+        # the records of the company the user is logged otherwise we have
+        # problem with this rule: https://shorturl.at/pwBIJ
+
         sol_agents = self.env["sale.order.line.agent"].search(
-            [("agent_id", operator, value)]
+            [
+                ("agent_id", operator, value),
+                ("object_id.company_id", "=", self.env.company.id),
+            ]
         )
         return [("id", "in", sol_agents.mapped("object_id.order_id").ids)]
 


### PR DESCRIPTION
I have the following problem.
I have an installation of odoo with 9 companys, I have three agents. The agent is agent for more contact in every company.
So if I try from UI to use that searc, I obtain the following error:

![image](https://github.com/OCA/commission/assets/43987335/ef582c60-6c00-44d2-9311-02057590aa73)
https://github.com/OCA/commission/blob/6c7c904711397dc93d06801d93533839194904a7/sale_commission/models/sale_order.py#L25

Steps to reproduce the behavior:

-Create one o more agent
- Create 2 or more company
- create some contact in every company ad assign the same agent
- Now create an order in every company to a contact have the sames agents
- Now try to search in base on field partner_agent_ids and have the problem on the screen


with this fix after recover all record  sale.order.line.agent respect the search, I filter the record in base of the company the user is logged