### PR TITLE
[15.0][FIX] account_commission: use Form() in tests

### DIFF
--- a/account_commission/tests/test_account_commission.py
+++ b/account_commission/tests/test_account_commission.py
@@ -498,7 +498,7 @@ class TestAccountCommission(TestCommissionBase):
         )
         self.assertEqual(2, len(settlements))
 
-    def test_invoice_parcial_refund(self):
+    def test_invoice_partial_refund(self):
         commission = self.commission_net_paid
         agent = self.agent_monthly
         today = fields.Date.today()
@@ -528,20 +528,12 @@ class TestAccountCommission(TestCommissionBase):
                 }
             )
         )
-        refund = self.env["account.move"].browse(
-            move_reversal.reverse_moves()["res_id"]
+        refund_form = Form(
+            self.env["account.move"].browse(move_reversal.reverse_moves()["res_id"])
         )
-        refund.write(
-            {
-                "invoice_line_ids": [
-                    (
-                        1,
-                        refund.invoice_line_ids[:1].id,
-                        {"price_unit": refund.invoice_line_ids[:1].price_unit - 2},
-                    )
-                ]
-            }
-        )
+        with refund_form.invoice_line_ids.edit(0) as line:
+            line.price_unit -= 2
+        refund = refund_form.save()
         refund.action_post()
         # Register payment for the refund
         register_payments = (
@@ -604,20 +596,12 @@ class TestAccountCommission(TestCommissionBase):
                 }
             )
         )
-        invoice2 = self.env["account.move"].browse(
-            move_reversal.reverse_moves()["res_id"]
+        invoice2_form = Form(
+            self.env["account.move"].browse(move_reversal.reverse_moves()["res_id"])
         )
-        invoice2.write(
-            {
-                "invoice_line_ids": [
-                    (
-                        1,
-                        invoice2.invoice_line_ids[:1].id,
-                        {"price_unit": invoice2.invoice_line_ids[:1].price_unit - 2},
-                    )
-                ]
-            }
-        )
+        with invoice2_form.invoice_line_ids.edit(0) as line:
+            line.price_unit -= 2
+        invoice2 = invoice2_form.save()
         invoice2.action_post()
         # Register payment for the new invoice
         payment_journal = self.env["account.journal"].search(


### PR DESCRIPTION
Not using Form() in tests can lead to some tricky integration tests issues. In this case, just overriding _recompute_payment_terms_lines with a new context in a third module wasn't making these true.

cc @Tecnativa TT47134

please review @pedrobaeza @victoralmau @Tisho99 