### PR TITLE
[16.0][FIX] sale_commission: ensure currency

### DIFF
--- a/sale_commission/tests/test_sale_commission.py
+++ b/sale_commission/tests/test_sale_commission.py
@@ -15,6 +15,13 @@ class TestSaleCommission(TestAccountCommission):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.pricelist = cls.env["product.pricelist"].create(
+            {
+                "name": "Pricelist for tests",
+                "currency_id": cls.company.currency_id.id,
+            }
+        )
+        cls.partner.property_product_pricelist = cls.pricelist
         cls.sale_order_model = cls.env["sale.order"]
         cls.advance_inv_model = cls.env["sale.advance.payment.inv"]
         cls.product.write({"invoice_policy": "order"})


### PR DESCRIPTION
fw of https://github.com/OCA/commission/pull/512


We should ensure that the partner's currency is the one in the company to avoid test integration issues

cc @Tecnativa TT38303

please review @pedrobaeza @victoralmau 