### PR TITLE
[17.0] [FIX] commission: partner view agent

### DIFF
--- a/commission/views/res_partner_views.xml
+++ b/commission/views/res_partner_views.xml
@@ -6,9 +6,9 @@
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="priority" eval="18" />
         <field name="arch" type="xml">
-            <field name="vat" position="after">
+            <xpath expr="//group/group[//field[@name='vat']]" position="inside">
                 <field name="agent" string="Agent" />
-            </field>
+            </xpath>
             <xpath
                 expr="//page[@name='sales_purchases']//field[@name='user_id']"
                 position="after"


### PR DESCRIPTION
In v17, the commission module has an incompatibility with the base_vat module, because the "vat" field of the partner form is moved inside a new div in [its views](https://github.com/odoo/odoo/blob/e0ee100b55c58a8d0968cf5c536a4cdb0d72b667/addons/base_vat/views/res_partner_views.xml#L16), and the "agent" field is placed before that field inside the commission module.

As a result, the "agent" field is displayed without tag in the partner form

![image](https://github.com/OCA/commission/assets/45785416/ea4a7dd2-9c9a-4f48-aa4a-628111a61aa6)

This PR edits the xpath to always put the field at the end of the vat group

T-5880