### PR TITLE
[14.0] [FIX] sale_commission_geo_assign: reset item_agent_ids on replace

### DIFF
--- a/sale_commission_geo_assign/wizard/wizard_geo_assign_partner.py
+++ b/sale_commission_geo_assign/wizard/wizard_geo_assign_partner.py
@@ -47,6 +47,10 @@ class WizardGeoAssign(models.TransientModel):
                         "agent_ids": [(5, 0, 0)],
                     }
                 )
+                if "commission_item_agent_ids" in partner._fields:
+                    # compatibility with 'sale_commission_product_criteria_domain'
+                    partner.commission_item_agent_ids.unlink()
+
             for agent in agents:
                 self.update_partner_data(partner, agent)
 


### PR DESCRIPTION
Without resetting this lines, the commission_item_group doesn't get updated properly, so to get the right lines you would have to manually delete them and then run the wizard again.

This PR fixes the explained issue

edit: <del>I'm also adding me and my team as maintainers of this module</del> (added maintainers in https://github.com/OCA/commission/pull/529)