### PR TITLE
[14.0][FIX] sale_commission_geo_assign_product_domain: clear groups

### DIFF
--- a/sale_commission_geo_assign_product_domain/models/res_partner.py
+++ b/sale_commission_geo_assign_product_domain/models/res_partner.py
@@ -23,3 +23,12 @@ class ResPartner(models.Model):
                     "agent_zip_to": False,
                 }
             )
+
+    @api.onchange("commission_id")
+    def _onchange_commission_id(self):
+        super()._onchange_commission_id()
+        self.update(
+            {
+                "commission_geo_group_ids": [(5, 0, 0)],
+            }
+        )

--- a/sale_commission_product_criteria_domain/models/partner.py
+++ b/sale_commission_product_criteria_domain/models/partner.py
@@ -62,6 +62,14 @@ class ResPartner(models.Model):
                     {"commission_item_agent_ids": [(0, 0, line) for line in to_create]}
                 )
 
+    @api.onchange("commission_id")
+    def _onchange_commission_id(self):
+        self.update(
+            {
+                "allowed_commission_group_ids": [(5, 0, 0)],
+            }
+        )
+
     def write(self, vals):
         res = super().write(vals)
         for partner in self:


### PR DESCRIPTION
Clear allowed_commission_group_ids and commission_geo_group_ids when commission_id was changed.