### PR TITLE
[14.0] [FIX] sale_commission_check_deposit: check date maturity

### DIFF
--- a/sale_commission_check_deposit/wizard/wizard_check_settle.py
+++ b/sale_commission_check_deposit/wizard/wizard_check_settle.py
@@ -34,9 +34,10 @@ class SaleCommissionMakeSettle(models.TransientModel):
             ]
         )
         return all(
-            [
+            x.date_maturity
+            and (
                 x.date_maturity + timedelta(days=x.journal_id.safety_days)
                 < self.date_payment_to
-                for x in move_lines
-            ]
+            )
+            for x in move_lines
         )


### PR DESCRIPTION
Check that all of the lines have `date_maturity` or ignore the invoice.

If an invoice with at least a line without `date_maturity` is kept in consideration, this would raise an error.