### PR TITLE
[FIX] sale_commission_salesman: partner fetch for agents creation on move lines

### DIFF
--- a/sale_commission_salesman/models/account_move.py
+++ b/sale_commission_salesman/models/account_move.py
@@ -18,7 +18,7 @@ class AccountMoveLine(models.Model):
             and x.product_id
             and not x.agent_ids
         ):
-            partner = self.move_id.invoice_user_id.partner_id
+            partner = record.move_id.invoice_user_id.partner_id
             if partner.agent and partner.salesman_as_agent:
-                record.agent_ids = [(0, 0, self._prepare_agent_vals(partner))]
+                record.agent_ids = [(0, 0, record._prepare_agent_vals(partner))]
         return result


### PR DESCRIPTION
Fetch the partner by move line record instead of fetching all partners for all invoice users related to the moves. The previous method could fetch more than one partner, including those not related to the move, when multiple lines for different moves are being processed, causing an error when trying to obtain the values of the `agent` and `salesman_as_agent` fields.