### PR TITLE
[15.0][FIX] *commission: Remove related from commission_free

### DIFF
--- a/account_commission/views/account_move_views.xml
+++ b/account_commission/views/account_move_views.xml
@@ -31,7 +31,7 @@
                     attrs="{'invisible': [('agent_ids', '=', [])], 'readonly': [('any_settled', '=', True)]}"
                 >
                     <field name="any_settled" invisible="1" />
-                    <field name="commission_free" force_save="1" />
+                    <field name="commission_free" force_save="1" readonly="1" />
                     <field
                         name="agent_ids"
                         attrs="{'readonly': [('commission_free', '=', True)]}"

--- a/commission/models/commission_mixin.py
+++ b/commission/models/commission_mixin.py
@@ -23,9 +23,9 @@ class CommissionMixin(models.AbstractModel):
     product_id = fields.Many2one(comodel_name="product.product", string="Product")
     commission_free = fields.Boolean(
         string="Comm. free",
-        related="product_id.commission_free",
+        compute="_compute_commission_free",
         store=True,
-        readonly=True,
+        readonly=False,
     )
     commission_status = fields.Char(
         compute="_compute_commission_status",
@@ -44,6 +44,11 @@ class CommissionMixin(models.AbstractModel):
                 or x.commission_id.settlement_type == settlement_type
             )
         return [(0, 0, self._prepare_agent_vals(agent)) for agent in agents]
+
+    @api.depends("product_id")
+    def _compute_commission_free(self):
+        for record in self:
+            record.commission_free = record.product_id.commission_free
 
     @api.depends("commission_free")
     def _compute_agent_ids(self):


### PR DESCRIPTION
Steps to reproduce:

- Create a product commission free.
- Do some invoices with that product.
- There's no commission on the invoices.
- Remove the "Commission free" check.

Result: all the past invoices are recomputed and now a commission appears. That's not acceptable, as past things shouldn't be changed if you change the definition from now on, and more if you already did the settlements.

This happens because the field in the invoice line is a related one, so changing the source, recomputes all the linked records.

Let's change it to a computed writable, being recomputed only when the product changes, not if we change the .

@Tecnativa TT50445