### PR TITLE
[16.0][IMP] account_commission: Index on invoice_agent_line_id

### DIFF
--- a/account_commission/models/commission_settlement.py
+++ b/account_commission/models/commission_settlement.py
@@ -163,7 +163,9 @@ class CommissionSettlement(models.Model):
 class SettlementLine(models.Model):
     _inherit = "commission.settlement.line"
 
-    invoice_agent_line_id = fields.Many2one(comodel_name="account.invoice.line.agent")
+    invoice_agent_line_id = fields.Many2one(
+        comodel_name="account.invoice.line.agent", index=True
+    )
     invoice_line_id = fields.Many2one(
         comodel_name="account.move.line",
         store=True,


### PR DESCRIPTION
A little improvement for indexing a column that it's used as FK. That way, deletions of agent lines in invoices are faster.

@Tecnativa TT50445