### PR TITLE
[14.0][FIX] sale_commission_product_criteria

### DIFF
--- a/sale_commission_product_criteria/models/sale.py
+++ b/sale_commission_product_criteria/models/sale.py
@@ -29,6 +29,8 @@ class SaleOrderLineAgent(models.Model):
                     order_line.product_id,
                     order_line.product_uom_qty,
                 )
+                if line.invoice_id.move_type and "refund" in line.invoice_id.move_type:
+                    line.amount = -line.amount
             else:
                 super(SaleOrderLineAgent, line)._compute_amount()
 


### PR DESCRIPTION
This fix is a reponse to Issue https://github.com/OCA/commission/issues/555
Basically fixes the creation of positive commissions for credit notes when sale_commission_product_criteria module