### PR TITLE
[15.0][IMP] commission: add the commission_ids field to the settlement and include it in the views

### DIFF
--- a/commission/models/commission_settlement.py
+++ b/commission/models/commission_settlement.py
@@ -60,6 +60,14 @@ class CommissionSettlement(models.Model):
         default=lambda self: self._default_company_id(),
         required=True,
     )
+    commission_ids = fields.Many2many(
+        comodel_name="commission", compute="_compute_commission_ids", store=True
+    )
+
+    @api.depends("line_ids.commission_id")
+    def _compute_commission_ids(self):
+        for rec in self:
+            rec.commission_ids = rec.line_ids.mapped("commission_id")
 
     def _default_currency_id(self):
         return self.env.company.currency_id.id

--- a/commission/views/commission_settlement_views.xml
+++ b/commission/views/commission_settlement_views.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <tree decoration-danger="state == 'cancel'">
                 <field name="agent_id" />
+                <field name="commission_ids" widget="many2many_tags" optional="show" />
                 <field name="company_id" groups="base.group_multi_company" />
                 <field name="date_from" />
                 <field name="date_to" />
@@ -27,6 +28,7 @@
         <field name="arch" type="xml">
             <search string="Settlement search">
                 <field name="agent_id" />
+                <field name="commission_ids" />
                 <field name="date_from" />
                 <field name="date_to" />
                 <field name="company_id" />
@@ -41,6 +43,11 @@
                         string="Agent"
                         name="group_agent"
                         context="{'group_by': 'agent_id'}"
+                    />
+                    <filter
+                        string="Commission"
+                        name="group_commission"
+                        context="{'group_by': 'commission_ids'}"
                     />
                     <filter
                         string="Date from month"
@@ -70,6 +77,7 @@
                     <group attrs="{'readonly': [('can_edit', '=', False)]}">
                         <group>
                             <field name="agent_id" />
+                            <field name="commission_ids" widget="many2many_tags" />
                             <field name="date_from" />
                             <field name="settlement_type" />
                         </group>


### PR DESCRIPTION
This PR improves the user experience by making it easier to understand which commission types are assigned to each settlement record, instead of having to check each settlement line individually.

@qrtl QT4840