### PR TITLE
[14.0][FIX]sale_commission_product_criteria: ignore error on create

### DIFF
--- a/sale_commission_product_criteria/models/commission.py
+++ b/sale_commission_product_criteria/models/commission.py
@@ -45,6 +45,8 @@ class SaleCommission(models.Model):
             )
 
     def check_type_change_allowed_moves(self):
+        if not self._origin:
+            return
         aila_ids = self.env["account.invoice.line.agent"].search(
             [("commission_id", "=", self._origin.id)]
         )

--- a/sale_commission_product_criteria_discount/README.rst
+++ b/sale_commission_product_criteria_discount/README.rst
@@ -89,13 +89,22 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
+.. |maintainer-aleuffre| image:: https://github.com/aleuffre.png?size=40px
+    :target: https://github.com/aleuffre
+    :alt: aleuffre
 .. |maintainer-ilyasProgrammer| image:: https://github.com/ilyasProgrammer.png?size=40px
     :target: https://github.com/ilyasProgrammer
     :alt: ilyasProgrammer
+.. |maintainer-renda-dev| image:: https://github.com/renda-dev.png?size=40px
+    :target: https://github.com/renda-dev
+    :alt: renda-dev
+.. |maintainer-PicchiSeba| image:: https://github.com/PicchiSeba.png?size=40px
+    :target: https://github.com/PicchiSeba
+    :alt: PicchiSeba
 
-Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-ilyasProgrammer| 
+|maintainer-aleuffre| |maintainer-ilyasProgrammer| |maintainer-renda-dev| |maintainer-PicchiSeba| 
 
 This module is part of the `OCA/commission <https://github.com/OCA/commission/tree/14.0/sale_commission_product_criteria_discount>`_ project on GitHub.
 

--- a/sale_commission_product_criteria_discount/__manifest__.py
+++ b/sale_commission_product_criteria_discount/__manifest__.py
@@ -6,7 +6,12 @@
     "version": "14.0.1.0.2",
     "author": "Ilyas," "Ooops404," "Odoo Community Association (OCA)",
     "contributors": ["Ilyas"],
-    "maintainers": ["ilyasProgrammer"],
+    "maintainers": [
+        "aleuffre",
+        "ilyasProgrammer",
+        "renda-dev",
+        "PicchiSeba",
+    ],
     "website": "https://github.com/OCA/commission",
     "category": "Sales Management",
     "license": "AGPL-3",

--- a/sale_commission_product_criteria_discount/static/description/index.html
+++ b/sale_commission_product_criteria_discount/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -422,12 +422,14 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
-<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/ilyasProgrammer"><img alt="ilyasProgrammer" src="https://github.com/ilyasProgrammer.png?size=40px" /></a></p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/aleuffre"><img alt="aleuffre" src="https://github.com/aleuffre.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/ilyasProgrammer"><img alt="ilyasProgrammer" src="https://github.com/ilyasProgrammer.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/renda-dev"><img alt="renda-dev" src="https://github.com/renda-dev.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/PicchiSeba"><img alt="PicchiSeba" src="https://github.com/PicchiSeba.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/commission/tree/14.0/sale_commission_product_criteria_discount">OCA/commission</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
Clicking the "Create" button for commision types, the exception at the end of `check_type_change_allowed_moves` is  raised, without even landing in the commission type form.
In this PR we make sure the commission exists in the first place