### PR TITLE
[14.0][FIX] account_commission: revert settlement in invoiced state to settled when deleting settlement invoice

### DIFF
--- a/sale_commission/models/account_move.py
+++ b/sale_commission/models/account_move.py
@@ -89,6 +89,13 @@ class AccountMove(models.Model):
                 res["arch"] = etree.tostring(invoice_xml)
         return res
 
+    def unlink(self):
+        """Put 'invoiced' settlements associated to the invoices back in settled state."""
+        self.invoice_line_ids.settlement_id.filtered(
+            lambda s: s.state == "invoiced"
+        ).write({"state": "settled"})
+        return super().unlink()
+
 
 class AccountMoveLine(models.Model):
     _inherit = [

--- a/sale_commission/tests/test_sale_commission.py
+++ b/sale_commission/tests/test_sale_commission.py
@@ -692,3 +692,19 @@ class TestSaleCommission(SavepointCase):
         )
         self.assertEqual(1, len(settlements))
         self.assertEqual(1, len(settlements.line_ids))
+
+    def test_unlink_settlement_invoice(self):
+        self._create_order_and_invoice_and_settle(
+            self.agent_quaterly,
+            self.env.ref("sale_commission.demo_commission"),
+            1,
+        )
+        settlements = self.settle_model.search([("state", "=", "settled")])
+        invoices = settlements.make_invoices(self.journal, self.commission_product)
+        self.assertTrue(
+            all(state == "invoiced" for state in settlements.mapped("state"))
+        )
+        invoices.unlink()
+        self.assertTrue(
+            all(state == "settled" for state in settlements.mapped("state"))
+        )


### PR DESCRIPTION
Backport of https://github.com/OCA/commission/pull/416/ from v16

Commit 225e3a0804db92b3eb89fd479a39a51af1953209