### PR TITLE
[IMP] account_commission: Settle based on payment date

### DIFF
--- a/account_commission/README.rst
+++ b/account_commission/README.rst
@@ -48,8 +48,10 @@ For selecting invoice status in commissions:
 
    * **Invoice Based**: Commissions are settled when the invoice is issued.
    * **Payment Based**: Commissions are settled when the invoice is paid or refunded.
-     Note that when refunding an invoice, the corresponding reversed commission will
-     be settled as well, resulting in a 0 net commission between both operations.
+   * **Payment Date Based**: Commissions are settled based on the payment date.
+
+   Note that when refunding an invoice, the corresponding reversed commission will
+   be settled as well, resulting in a 0 net commission between both operations.
 
 Usage
 =====
@@ -138,6 +140,10 @@ Contributors
 * `Studio73 <https://www.studio73.es>`__:
 
   * Ethan Hildick
+
+* `Aion Tech <https://aiontech.company/>`_:
+
+  * Simone Rubino <simone.rubino@aion-tech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_commission/models/account_move.py
+++ b/account_commission/models/account_move.py
@@ -246,12 +246,11 @@ class AccountInvoiceLineAgent(models.Model):
                 )
 
     def _skip_settlement(self):
-        """This function should return False if the commission can be paid.
-
-        :return: bool
-        """
         self.ensure_one()
         return (
             self.commission_id.invoice_state == "paid"
             and self.invoice_id.payment_state not in ["in_payment", "paid", "reversed"]
         ) or self.invoice_id.state != "posted"
+
+    def _get_commission_settlement_date(self):
+        return self.invoice_date

--- a/account_commission/models/commission.py
+++ b/account_commission/models/commission.py
@@ -7,10 +7,15 @@ class Commission(models.Model):
     _inherit = "commission"
 
     invoice_state = fields.Selection(
-        [("open", "Invoice Based"), ("paid", "Payment Based")],
+        [
+            ("open", "Invoice Based"),
+            ("paid", "Payment Based"),
+            ("paid_date", "Payment Date Based"),
+        ],
         string="Invoice Status",
         default="open",
         help="Select the invoice status for settling the commissions:\n"
         "* 'Invoice Based': Commissions are settled when the invoice is issued.\n"
-        "* 'Payment Based': Commissions are settled when the invoice is paid (or refunded).",
+        "* 'Payment Based': Commissions are settled when the invoice is paid (or refunded)\n."
+        "* 'Payment Date Based': Commissions are settled based on the payment date.",
     )

--- a/account_commission/models/commission_settlement.py
+++ b/account_commission/models/commission_settlement.py
@@ -172,6 +172,18 @@ class SettlementLine(models.Model):
         related="invoice_agent_line_id.object_id",
         string="Source invoice line",
     )
+    invoice_payment_date = fields.Date(
+        string="Payment date",
+        compute="_compute_invoice_payment_date",
+    )
+
+    def _compute_invoice_payment_date(self):
+        for line in self:
+            payments = line.invoice_line_id.move_id._get_reconciled_amls().move_id
+            line.invoice_payment_date = max(
+                payments.mapped("date"),
+                default=False,
+            )
 
     @api.depends("invoice_agent_line_id")
     def _compute_date(self):

--- a/account_commission/readme/CONFIGURE.rst
+++ b/account_commission/readme/CONFIGURE.rst
@@ -4,5 +4,7 @@ For selecting invoice status in commissions:
 
    * **Invoice Based**: Commissions are settled when the invoice is issued.
    * **Payment Based**: Commissions are settled when the invoice is paid or refunded.
-     Note that when refunding an invoice, the corresponding reversed commission will
-     be settled as well, resulting in a 0 net commission between both operations.
+   * **Payment Date Based**: Commissions are settled based on the payment date.
+
+   Note that when refunding an invoice, the corresponding reversed commission will
+   be settled as well, resulting in a 0 net commission between both operations.

--- a/account_commission/readme/CONTRIBUTORS.rst
+++ b/account_commission/readme/CONTRIBUTORS.rst
@@ -23,3 +23,7 @@
 * `Studio73 <https://www.studio73.es>`__:
 
   * Ethan Hildick
+
+* `Aion Tech <https://aiontech.company/>`_:
+
+  * Simone Rubino <simone.rubino@aion-tech.it>

--- a/account_commission/static/description/index.html
+++ b/account_commission/static/description/index.html
@@ -390,13 +390,15 @@ ul.auto-toc {
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
 <p>For selecting invoice status in commissions:</p>
-<ol class="arabic simple">
-<li>Edit or create a new record to select the invoice status for settling the commissions.<ul>
+<ol class="arabic">
+<li><p class="first">Edit or create a new record to select the invoice status for settling the commissions.</p>
+<ul class="simple">
 <li><strong>Invoice Based</strong>: Commissions are settled when the invoice is issued.</li>
-<li><strong>Payment Based</strong>: Commissions are settled when the invoice is paid or refunded.
-Note that when refunding an invoice, the corresponding reversed commission will
-be settled as well, resulting in a 0 net commission between both operations.</li>
+<li><strong>Payment Based</strong>: Commissions are settled when the invoice is paid or refunded.</li>
+<li><strong>Payment Date Based</strong>: Commissions are settled based on the payment date.</li>
 </ul>
+<p>Note that when refunding an invoice, the corresponding reversed commission will
+be settled as well, resulting in a 0 net commission between both operations.</p>
 </li>
 </ol>
 </div>
@@ -484,6 +486,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://www.studio73.es">Studio73</a>:<ul>
 <li>Ethan Hildick</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://aiontech.company/">Aion Tech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;aion-tech.it">simone.rubino&#64;aion-tech.it</a>&gt;</li>
 </ul>
 </li>
 </ul>

--- a/account_commission/views/commission_settlement_views.xml
+++ b/account_commission/views/commission_settlement_views.xml
@@ -47,6 +47,11 @@
                 position="after"
             >
                 <field
+                    name="invoice_payment_date"
+                    attrs="{'column_invisible': [('parent.settlement_type', '!=', 'sale_invoice')]}"
+                    groups="account.group_account_invoice"
+                />
+                <field
                     name="invoice_line_id"
                     attrs="{'column_invisible': [('parent.settlement_type', '!=', 'sale_invoice')]}"
                     groups="account.group_account_invoice"

--- a/account_commission/wizards/commission_make_settle.py
+++ b/account_commission/wizards/commission_make_settle.py
@@ -15,11 +15,18 @@ class CommissionMakeSettle(models.TransientModel):
     )
 
     def _get_account_settle_domain(self, agent, date_to_agent):
+        to_settle_agent_lines = self.env["account.invoice.line.agent"].search(
+            [
+                ("agent_id", "=", agent.id),
+                ("settled", "=", False),
+                ("object_id.display_type", "=", "product"),
+            ],
+        )
+        to_settle_agent_lines = to_settle_agent_lines.filtered(
+            lambda al: al._get_commission_settlement_date() < date_to_agent
+        )
         return [
-            ("invoice_date", "<", date_to_agent),
-            ("agent_id", "=", agent.id),
-            ("settled", "=", False),
-            ("object_id.display_type", "=", "product"),
+            ("id", "in", to_settle_agent_lines.ids),
         ]
 
     def _get_agent_lines(self, agent, date_to_agent):

--- a/commission/models/commission_mixin.py
+++ b/commission/models/commission_mixin.py
@@ -162,3 +162,14 @@ class CommissionLineMixin(models.AbstractModel):
     def _compute_commission_id(self):
         for record in self:
             record.commission_id = record.agent_id.commission_id
+
+    def _skip_settlement(self):
+        """This function should return False if the commission can be paid.
+
+        :return: bool
+        """
+        raise NotImplementedError()
+
+    def _get_commission_settlement_date(self):
+        """Date used to insert this line in a commission settlement."""
+        raise NotImplementedError()

--- a/commission/wizards/commission_make_settle.py
+++ b/commission/wizards/commission_make_settle.py
@@ -124,7 +124,6 @@ class CommissionMakeSettle(models.TransientModel):
             [("agent", "=", True)]
         )
         date_to = self.date_to
-        settlement_line_vals = []
         for agent in agents:
             date_to_agent = self._get_period_start(agent, date_to)
             # Get non settled elements
@@ -145,8 +144,9 @@ class CommissionMakeSettle(models.TransientModel):
                     pos += 1
                     if line._skip_settlement():
                         continue
-                    if line.invoice_date > sett_to:
-                        sett_from = self._get_period_start(agent, line.invoice_date)
+                    line_date = line._get_commission_settlement_date()
+                    if line_date > sett_to:
+                        sett_from = self._get_period_start(agent, line_date)
                         sett_to = self._get_next_period_date(agent, sett_from)
                         sett_to -= timedelta(days=1)
                         settlement = self._get_settlement(


### PR DESCRIPTION
Add a new "Invoice Status" to settle based on the payment date.
For instance: if the invoice is in January but its payment is in February, the invoice will be settled in February's settlement.