### PR TITLE
[FIX] sale_commission_agent_restrict: Lines access for agents

### DIFF
--- a/sale_commission_agent_restrict/views/sale_order_view.xml
+++ b/sale_commission_agent_restrict/views/sale_order_view.xml
@@ -6,14 +6,21 @@
 <odoo>
 
     <record model="ir.ui.view" id="view_sale_order_line_tree_mod">
-        <field name="name">Agent lines for user displaying only own commissions</field>
-        <field name="model">sale.order.line.agent</field>
-        <field name="priority">100</field>
+        <field
+            name="name"
+        >Sale Order line for user displaying only own commissions</field>
+        <field name="model">sale.order.line</field>
         <field name="mode">primary</field>
-        <field name="inherit_id" ref="sale_commission.view_sale_order_line_tree" />
+        <field name="inherit_id" ref="commission.view_commission_mixin_agent_only" />
         <field name="arch" type="xml">
-            <tree position="replace">
-                <tree create="false" edit="false" delete="false" editable="bottom">
+            <field name="agent_ids" position="inside">
+                <tree
+                    no_open="True"
+                    create="false"
+                    edit="false"
+                    delete="false"
+                    editable="bottom"
+                >
                     <field
                         name="agent_id"
                         context="{'default_agent': True, 'default_customer': False, 'default_supplier': True}"
@@ -22,7 +29,7 @@
                     <field name="commission_id" readonly="1" />
                     <field name="amount" readonly="1" />
                 </tree>
-            </tree>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
**Steps**:

1. Install **sale_commission_agent_restrict**
2. Create an internal user for an agent
3. Assign the group **Agent Access / Display only own commission data** to the created user
4. Create a sale order with commissions for the created agent
    Ensure that the salesman (`user_id`) of the created order is the current user, **not** the agent.
5. Log in with the created user
6. Open the order and click on the **Agents** button

**Observed**:
JS error:
> Error: Missing field string information for the field 'agent_id' from the 'sale.order.line' model

**Expected**:
See the agent's commissions