### PR TITLE
[14.0][FIX] sale_commission_partial_settlement: partial_commission computation

### DIFF
--- a/sale_commission_partial_settlement/__manifest__.py
+++ b/sale_commission_partial_settlement/__manifest__.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Nextev
 {
     "name": "Sales commissions based on paid amount",
-    "version": "14.0.1.2.0",
+    "version": "14.0.1.2.1",
     "author": "Nextev Srl," "Ooops," "Odoo Community Association (OCA)",
     "maintainers": ["aleuffre", "renda-dev", "PicchiSeba"],
     "category": "Sales Management",

--- a/sale_commission_partial_settlement/migrations/14.0.1.2.1/post-migrate.py
+++ b/sale_commission_partial_settlement/migrations/14.0.1.2.1/post-migrate.py
@@ -1,0 +1,14 @@
+from openupgradelib import openupgrade
+
+
+def recompute_partial_commission_settled(env):
+    """
+    Recompute field "partial_commission_settled"
+    of model "account.partial.reconcile"
+    """
+    env["account.partial.reconcile"].search([])._compute_partial_commission_settled()
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    recompute_partial_commission_settled(env)

--- a/sale_commission_partial_settlement/models/account_invoice_line_agent.py
+++ b/sale_commission_partial_settlement/models/account_invoice_line_agent.py
@@ -27,7 +27,10 @@ class AccountInvoiceLineAgent(models.Model):
             rec.partial_settled = sum(
                 ailap.amount
                 for ailap in rec.invoice_line_agent_partial_ids
-                if ailap.mapped("agent_line.settlement_id")[:1].state != "cancel"
+                if any(
+                    settlement.state != "cancel"
+                    for settlement in ailap.mapped("agent_line.settlement_id")
+                )
             )
 
     @api.depends(

--- a/sale_commission_partial_settlement/models/account_partial_reconcile.py
+++ b/sale_commission_partial_settlement/models/account_partial_reconcile.py
@@ -18,8 +18,9 @@ class AccountPartialReconcile(models.Model):
     )
     def _compute_partial_commission_settled(self):
         for rec in self:
-            rec.partial_commission_settled = bool(
-                rec.account_invoice_line_agent_partial_ids.filtered(
-                    lambda x: x.mapped("agent_line.settlement_id")[:1].state != "cancel"
+            rec.partial_commission_settled = any(
+                settlement.state != "cancel"
+                for settlement in rec.mapped(
+                    "account_invoice_line_agent_partial_ids.agent_line.settlement_id"
                 )
             )


### PR DESCRIPTION
Fixes an error where with two computations. A partial reconciliation with no partial settlements linked previously counted as settled.