### PR TITLE
[16.0][IMP] sale_commission: Recompute agents amount button

### DIFF
--- a/sale_commission/models/sale_order.py
+++ b/sale_commission/models/sale_order.py
@@ -42,6 +42,9 @@ class SaleOrder(models.Model):
     def recompute_lines_agents(self):
         self.mapped("order_line").recompute_agents()
 
+    def recompute_lines_agents_amount(self):
+        self.mapped("order_line").agent_ids._compute_amount()
+
 
 class SaleOrderLine(models.Model):
     _inherit = [

--- a/sale_commission/tests/test_sale_commission.py
+++ b/sale_commission/tests/test_sale_commission.py
@@ -136,6 +136,10 @@ class TestSaleCommission(TestAccountCommission):
         sale_order.recompute_lines_agents()
         agent = sale_order.order_line.agent_ids
         self._check_propagation(agent, self.commission_net_invoice, self.agent_monthly)
+        # Check recomputation of amount
+        agent.amount = 5
+        sale_order.recompute_lines_agents_amount()
+        self.assertEqual(agent.amount, 1)
 
     def test_sale_commission_invoice_line_agent(self):
         sale_order = self._create_sale_order(

--- a/sale_commission/views/sale_order_view.xml
+++ b/sale_commission/views/sale_order_view.xml
@@ -35,6 +35,12 @@
                         string="Regenerate agents"
                         states="draft,sent"
                     />
+                    <button
+                        name="recompute_lines_agents_amount"
+                        type="object"
+                        string="Recompute amounts"
+                        states="draft,sent"
+                    />
                 </group>
             </xpath>
         </field>


### PR DESCRIPTION
The module commission_formula standard behavior allows for the assignment of commissions based on formulas, such as the number of agents involved in a transaction. However, an issue arises when agents commissions are added based on the total number of agents.
For example, consider the rule: 10% / n_agents. This means:
- If there is 1 agent, they receive 10%.
- If there are 2 agents, each receives 5%.
And so on.

The expected result:
- Agent1 = 2.5
- Agent2 = 2.5
- Agent3 = 2.5
- Agent4 = 2.5

The actual result:
- Agent1 = 10
- Agent2 = 5
- Agent3 = 3.33
- Agent4 = 2.5

This PR solve the issue recomputing the amount for every agent on any agent line change