### PR TITLE
[16.0][IMP] comission: Fix product view

### DIFF
--- a/commission/views/product_template_views.xml
+++ b/commission/views/product_template_views.xml
@@ -5,12 +5,12 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
-            <label for="sale_ok" position="after">
-                <div>
+            <div name="options" position="inside">
+                <span class="d-inline-block">
                     <field name="commission_free" />
                     <label for="commission_free" />
-                </div>
-            </label>
+                </span>
+            </div>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
### Module

comission

### Describe the bug

The product view is not harmonized with the elements of product's header.

### To Reproduce

1. Choose one product and go inside it

(image from runboat OCA)

![imagen](https://github.com/user-attachments/assets/2e10e2bd-01b0-4ebf-8687-bbc4cdecbf82)

With this change, the product view look like this

![Selección_160](https://github.com/user-attachments/assets/56892044-73f2-446f-987f-76261182dac1)

**Affected versions:**

16.0