### PR TITLE
[FIX] account_commission: Use partner on the lang in order to avoid errors later with delegated partners

### DIFF
--- a/account_commission/models/commission_settlement.py
+++ b/account_commission/models/commission_settlement.py
@@ -94,7 +94,7 @@ class CommissionSettlement(models.Model):
                     (
                         "code",
                         "=",
-                        self.agent_id.lang or self.env.context.get("lang", "en_US"),
+                        partner.lang or self.env.context.get("lang", "en_US"),
                     )
                 ]
             )


### PR DESCRIPTION
If we try to invoice two agents with the same delegated partner, it fails