### PR TITLE
[17.0][IMP] account_commission: Extend grouped_report_lines to include grouping by invoice

### DIFF
--- a/account_commission/README.rst
+++ b/account_commission/README.rst
@@ -36,6 +36,9 @@ agents.
 
 This module depends on the commission module.
 
+Additionally, it extends the grouped settlement report from the
+commission module to include a grouping by invoice
+
 **Table of contents**
 
 .. contents::
@@ -49,10 +52,10 @@ For selecting invoice status in commissions:
 1. Edit or create a new record to select the invoice status for settling
    the commissions.
 
-   -  **Invoice Based**: Commissions are settled when the invoice is
-      issued.
-   -  **Payment Based**: Commissions are settled when the invoice is
-      paid.
+   - **Invoice Based**: Commissions are settled when the invoice is
+     issued.
+   - **Payment Based**: Commissions are settled when the invoice is
+     paid.
 
 Usage
 =====
@@ -81,13 +84,12 @@ For invoicing the settlements (only for external agents):
 1. Go to *Invoicing > Commissions > Create Commission Invoices*.
 2. On the window that appears, you can select following data:
 
-   -  Product. It should be a service product for being coherent.
-   -  Journal: To be selected between existing purchase journals.
-   -  Date: If you want to choose a specific invoice date. You can leave
-      it blank if you prefer.
-   -  Settlements: For selecting specific settlements to invoice. You
-      can leave it blank as well for invoicing all the pending
-      settlements.
+   - Product. It should be a service product for being coherent.
+   - Journal: To be selected between existing purchase journals.
+   - Date: If you want to choose a specific invoice date. You can leave
+     it blank if you prefer.
+   - Settlements: For selecting specific settlements to invoice. You can
+     leave it blank as well for invoicing all the pending settlements.
 
 If you want to invoice a/some specific settlement/s:
 
@@ -118,34 +120,36 @@ Authors
 Contributors
 ------------
 
--  Pexego.
--  Davide Corio <davide.corio@domsense.com>
--  Joao Alfredo Gama Batista <joao.gama@savoirfairelinux.com>
--  Sandy Carter <sandy.carter@savoirfairelinux.com>
--  Giorgio Borelli <giorgio.borelli@abstract.it>
--  Daniel Campos <danielcampos@avanzosc.es>
--  Oihane Crucelaegui <oihanecruce@gmail.com>
--  Nicola Malcontenti <nicola.malcontenti@agilebg.com>
--  Aitor Bouzas <aitor.bouzas@adaptivecity.com>
--  Alexei Rivera <arivera@archeti.com>
--  Mina Samir <minaw349@outlook.com>
--  `Tecnativa <https://www.tecnativa.com>`__:
+- Pexego.
+- Davide Corio <davide.corio@domsense.com>
+- Joao Alfredo Gama Batista <joao.gama@savoirfairelinux.com>
+- Sandy Carter <sandy.carter@savoirfairelinux.com>
+- Giorgio Borelli <giorgio.borelli@abstract.it>
+- Daniel Campos <danielcampos@avanzosc.es>
+- Oihane Crucelaegui <oihanecruce@gmail.com>
+- Nicola Malcontenti <nicola.malcontenti@agilebg.com>
+- Aitor Bouzas <aitor.bouzas@adaptivecity.com>
+- Alexei Rivera <arivera@archeti.com>
+- Mina Samir <minaw349@outlook.com>
+- `Tecnativa <https://www.tecnativa.com>`__:
 
-   -  Pedro M. Baeza
-   -  Manuel Calero
+  - Pedro M. Baeza
+  - Manuel Calero
 
--  `Quartile <https://www.quartile.co>`__:
+- `Quartile <https://www.quartile.co>`__:
 
-   -  Aung Ko Ko Lin
-   -  Yoshi Tashiro
+  - Aung Ko Ko Lin
+  - Yoshi Tashiro
 
--  `Studio73 <https://www.studio73.es>`__:
+- `Studio73 <https://www.studio73.es>`__:
 
-   -  Ethan Hildick
+  - Ethan Hildick
 
--  `Sygel <https://www.sygel.es>`__:
+- `Sygel <https://www.sygel.es>`__:
 
-   -  Alberto Martínez
+  - Alberto Martínez
+  - Valentín Vinagre
+  - Ángel Rivas
 
 Maintainers
 -----------

--- a/account_commission/__manifest__.py
+++ b/account_commission/__manifest__.py
@@ -21,6 +21,7 @@
         "views/commission_settlement_views.xml",
         "views/commission_views.xml",
         "views/report_settlement_templates.xml",
+        "views/grouped_report_settlement_templates.xml",
         "report/commission_analysis_view.xml",
         "wizards/wizard_invoice.xml",
     ],

--- a/account_commission/models/commission_settlement.py
+++ b/account_commission/models/commission_settlement.py
@@ -159,6 +159,42 @@ class CommissionSettlement(models.Model):
         self.write({"state": "invoiced"})
         return invoices
 
+    def grouped_report_lines(self):
+        self.ensure_one()
+        if self.settlement_type == "sale_invoice":
+            grouped_res = {}
+            for line in self.line_ids:
+                origin = (
+                    line.invoice_line_id.move_id if line.invoice_line_id else "Manual"
+                )
+                move = line.invoice_line_id.move_id
+                sign = -1 if move and "refund" in move.move_type else 1
+                group = grouped_res.setdefault(
+                    (line.date, origin),
+                    {"commission": 0.0, "base_commission": 0.0},
+                )
+                if move:
+                    group["base_commission"] += (
+                        sign * line.invoice_line_id.price_subtotal
+                    )
+                group["commission"] += line.settled_amount
+            res = []
+            for (date, origin), values in grouped_res.items():
+                res.append(
+                    {
+                        "date": date,
+                        "settled_amount": values["commission"],
+                        "base_commission": values["base_commission"],
+                        "invoice": origin if isinstance(origin, str) else origin.name,
+                        "partner": ""
+                        if isinstance(origin, str)
+                        else origin.partner_id.display_name,
+                    }
+                )
+        else:
+            res = super().grouped_report_lines()
+        return res
+
 
 class SettlementLine(models.Model):
     _inherit = "commission.settlement.line"

--- a/account_commission/readme/CONTRIBUTORS.md
+++ b/account_commission/readme/CONTRIBUTORS.md
@@ -19,3 +19,5 @@
   - Ethan Hildick
 - [Sygel](https://www.sygel.es):
   - Alberto Martínez
+  - Valentín Vinagre
+  - Ángel Rivas

--- a/account_commission/readme/DESCRIPTION.md
+++ b/account_commission/readme/DESCRIPTION.md
@@ -5,3 +5,6 @@ It also allows to create vendor bills from settlements for external
 agents.
 
 This module depends on the commission module.
+
+Additionally, it extends the grouped settlement report from the commission module
+to include a grouping by invoice

--- a/account_commission/static/description/index.html
+++ b/account_commission/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -374,6 +375,8 @@ ul.auto-toc {
 <p>It also allows to create vendor bills from settlements for external
 agents.</p>
 <p>This module depends on the commission module.</p>
+<p>Additionally, it extends the grouped settlement report from the
+commission module to include a grouping by invoice</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -431,9 +434,8 @@ partner on the invoice having already inserted lines.</li>
 <li>Journal: To be selected between existing purchase journals.</li>
 <li>Date: If you want to choose a specific invoice date. You can leave
 it blank if you prefer.</li>
-<li>Settlements: For selecting specific settlements to invoice. You
-can leave it blank as well for invoicing all the pending
-settlements.</li>
+<li>Settlements: For selecting specific settlements to invoice. You can
+leave it blank as well for invoicing all the pending settlements.</li>
 </ul>
 </li>
 </ol>
@@ -492,6 +494,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://www.sygel.es">Sygel</a>:<ul>
 <li>Alberto Martínez</li>
+<li>Valentín Vinagre</li>
+<li>Ángel Rivas</li>
 </ul>
 </li>
 </ul>
@@ -499,7 +503,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_commission/tests/test_account_commission.py
+++ b/account_commission/tests/test_account_commission.py
@@ -532,3 +532,82 @@ class TestAccountCommission(TestCommissionBase):
             ]
         )
         self.assertEqual(2, len(settlements))
+
+    def test_grouped_report_lines_sale_invoice(self):
+        """Test grouped report lines for settlements coming from sale invoices."""
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "invoice_date": fields.Date.today(),
+                "invoice_line_ids": [
+                    (0, 0, {"name": "Line 1", "price_unit": 100.0, "quantity": 1.0}),
+                    (0, 0, {"name": "Line 2", "price_unit": 50.0, "quantity": 1.0}),
+                ],
+            }
+        )
+        agent_line1 = self.env["account.invoice.line.agent"].create(
+            {
+                "object_id": invoice.invoice_line_ids[0].id,
+                "commission_id": self.commission_net_paid.id,
+                "amount": 20.0,
+                "agent_id": self.agent_monthly.id,
+                "invoice_date": fields.Date.today(),
+                "company_id": self.company.id,
+            }
+        )
+        agent_line2 = self.env["account.invoice.line.agent"].create(
+            {
+                "object_id": invoice.invoice_line_ids[1].id,
+                "commission_id": self.commission_net_paid.id,
+                "amount": 10.0,
+                "agent_id": self.agent_monthly.id,
+                "invoice_date": fields.Date.today(),
+                "company_id": self.company.id,
+            }
+        )
+        settlement = self.settle_model.create(
+            {
+                "agent_id": self.agent_monthly.id,
+                "date_from": fields.Date.today(),
+                "date_to": fields.Date.today(),
+                "settlement_type": "sale_invoice",
+                "company_id": self.company.id,
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "date": fields.Date.today(),
+                            "agent_id": self.agent_monthly.id,
+                            "commission_id": self.commission_net_paid.id,
+                            "settled_amount": 20.0,
+                            "invoice_agent_line_id": agent_line1.id,
+                            "currency_id": self.company.currency_id.id,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "date": fields.Date.today(),
+                            "agent_id": self.agent_monthly.id,
+                            "commission_id": self.commission_net_paid.id,
+                            "settled_amount": 10.0,
+                            "invoice_agent_line_id": agent_line2.id,
+                            "currency_id": self.company.currency_id.id,
+                        },
+                    ),
+                ],
+            }
+        )
+        grouped_lines = settlement.grouped_report_lines()
+        self.assertEqual(
+            len(grouped_lines), 1, "Lines from same invoice should be grouped together"
+        )
+
+        gl = grouped_lines[0]
+        self.assertEqual(
+            gl["settled_amount"], 30.0, "Grouped settled amount should be summed"
+        )
+        self.assertEqual(gl["invoice"], invoice.name)

--- a/account_commission/views/grouped_report_settlement_templates.xml
+++ b/account_commission/views/grouped_report_settlement_templates.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="grouped_report_settlement_document"
+        inherit_id="commission.grouped_report_settlement_document"
+    >
+        <xpath expr="//th[@name='th_commission']" position="attributes">
+            <attribute name="t-if">o.settlement_type != 'sale_invoice'</attribute>
+        </xpath>
+        <xpath expr="//td[@name='td_commission']" position="attributes">
+            <attribute name="t-if">o.settlement_type != 'sale_invoice'</attribute>
+        </xpath>
+        <xpath expr="//th[@name='th_date']" position="after">
+            <t t-if="o.settlement_type == 'sale_invoice'">
+                <th class="text-start">Invoice</th>
+                <th class="text-start">Partner</th>
+                <th class="text-start">Subtotal</th>
+            </t>
+        </xpath>
+        <xpath expr="//td[@name='td_date']" position="after">
+            <t t-if="o.settlement_type == 'sale_invoice'">
+                <td><span t-out="l.get('invoice')" /></td>
+                <td><span t-out="l.get('partner')" /></td>
+                <td><span t-out="round(l.get('base_commission', 0.0), 2)" /></td>
+            </t>
+        </xpath>
+        <xpath expr="//tr[td[@name='td_total']]" position="after">
+            <tr t-if="o.settlement_type == 'sale_invoice'">
+                <td />
+                <td />
+                <td />
+                <td class="text-end"><strong>Total</strong></td>
+                <td class="text-end">
+                    <span
+                        t-field="o.total"
+                        t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"
+                    />
+                </td>
+            </tr>
+        </xpath>
+        <xpath expr="//tr[td[@name='td_total']]" position="attributes">
+            <attribute name="t-if">o.settlement_type != 'sale_invoice'</attribute>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
@HaraldPanten , @ValentinVinagre , @Jaimermaccione 

This PR extends the functionality recently added to the commission module, which provides a report grouped by date. In this module, the same report is additionally grouped by invoice.

Depends on:

- [ ]  https://github.com/OCA/commission/pull/648


[T-8663]