### PR TITLE
[FIX][16.0] sale_commission_product_criteria_domain: Negative commissions on refund invoices

### DIFF
--- a/sale_commission_product_criteria_domain/models/account_invoice_line_agent.py
+++ b/sale_commission_product_criteria_domain/models/account_invoice_line_agent.py
@@ -25,6 +25,9 @@ class AccountInvoiceLineAgent(models.Model):
                     inv_line.product_id,
                     inv_line.quantity,
                 )
+                # Refunds commissions are negative
+                if inv_line.move_type and "refund" in inv_line.move_type:
+                    line.amount = -line.amount
             else:
                 res = super(AccountInvoiceLineAgent, line)._compute_amount()
         return res


### PR DESCRIPTION
When a refund invoice happens on a Commission type of "product" (Product Criteria with Domain), amount in refund invoices are always positive and Settlement Report shows like positive commissions.

With this fix, refund types gaves negative commissions like https://github.com/OCA/commission/blob/16.0/account_commission/models/account_move.py#L217-L219 on model "account.invoice.line.agent".

## PR Series
- sale_commission_product_criteria: https://github.com/OCA/commission/pull/656
- **sale_commission_product_criteria_domain**: https://github.com/OCA/commission/pull/657
---

MT-12373 @moduon @pedrobaeza @ilyasProgrammer @rafaelbn @yajo @Gelojr @fcvalgar please review if you want 😄 