### PR TITLE
[FIX][16.0] sale_commission: UX improvements

### DIFF
--- a/sale_commission/views/sale_order_view.xml
+++ b/sale_commission/views/sale_order_view.xml
@@ -28,19 +28,28 @@
                 />
             </field>
             <xpath expr="//field[@name='note']" position="after">
-                <group name="group_recompute_commission">
-                    <button
-                        name="recompute_lines_agents"
-                        type="object"
-                        string="Regenerate agents"
-                        states="draft,sent"
-                    />
-                    <button
-                        name="recompute_lines_agents_amount"
-                        type="object"
-                        string="Recompute amounts"
-                        states="draft,sent"
-                    />
+                <group
+                    name="group_recompute_commission"
+                    attrs="{'invisible': [('state', 'not in', ['draft', 'sent'])]}"
+                    colspan="2"
+                    groups="commission.group_commission_user"
+                    string="Commission actions"
+                >
+                    <div class="o_row" colspan="2">
+                        <button
+                            name="recompute_lines_agents"
+                            type="object"
+                            string="Regenerate agents"
+                            class="btn-secondary me-3"
+                            groups="commission.group_commission_manager"
+                        />
+                        <button
+                            name="recompute_lines_agents_amount"
+                            type="object"
+                            string="Recompute amounts"
+                            class="btn-secondary"
+                        />
+                    </div>
                 </group>
             </xpath>
         </field>


### PR DESCRIPTION
UX improvements:
- Commission actions are now in one line with and visible to Commission users: Recomputation of prices are triggered automatically, so, no need to allow anyone to restore agents if a Commission Manager added a new one. Regenerate agents button are only allowed to Commission Managers (the one who could add more agents)

MT-12373 @moduon @rafaelbn @pedrobaeza @yajo @Gelojr @fcvalgar please review if you want 😄 