### PR TITLE
[14.0][FIX] sale_commission_product_criteria: Get items without commission

### DIFF
--- a/sale_commission_product_criteria/README.rst
+++ b/sale_commission_product_criteria/README.rst
@@ -86,6 +86,9 @@ Contributors
 * `Ooops404 <https://www.ooops404.com>`__:
 
   * Ilyas <irazor147@gmail.com>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_commission_product_criteria/models/sale_commission_line_mixin.py
+++ b/sale_commission_product_criteria/models/sale_commission_line_mixin.py
@@ -17,38 +17,51 @@ class SaleCommissionLineMixin(models.AbstractModel):
         copy=True,
     )
 
-    def _get_commission_items(self, commission, product):
-        # Method replaced
+    def _commission_items_from(self):
+        return """ commission_item AS item
+            LEFT JOIN product_category AS categ ON item.categ_id = categ.id
+        """
+
+    def _commission_items_where(self):
+        return """ (item.product_tmpl_id IS NULL OR item.product_tmpl_id = any(%(prod_tmpls)s))
+            AND (item.product_id IS NULL OR item.product_id = any(%(prod_prods)s))
+            AND (item.categ_id IS NULL OR item.categ_id = any(%(categs)s))
+            AND (item.commission_id = %(commission)s)
+            AND (item.active = TRUE)
+        """
+
+    def _commission_items_order(self):
+        return """item.applied_on,
+            item.based_on,
+            categ.complete_name desc
+        """
+
+    def _commission_items_query(self):
+        return f"""
+            SELECT item.id
+            FROM {self._commission_items_from()}
+            WHERE {self._commission_items_where()}
+            ORDER BY {self._commission_items_order()}
+        """
+
+    def _commission_items_query_params(self, commission, product):
         categ_ids = {}
         categ = product.categ_id
         while categ:
             categ_ids[categ.id] = True
             categ = categ.parent_id
         categ_ids = list(categ_ids)
-        # Select all suitable items. Order by best match
-        # (priority is: all/cat/subcat/product/variant).
+        return {
+            "prod_tmpls": product.product_tmpl_id.ids,
+            "prod_prods": product.ids,
+            "categs": categ_ids,
+            "commission": commission._origin.id,
+        }
+
+    def _get_commission_items(self, commission, product):
         self.env.cr.execute(
-            """
-            SELECT
-                item.id
-            FROM
-                commission_item AS item
-            LEFT JOIN product_category AS categ ON item.categ_id = categ.id
-            WHERE
-                (item.product_tmpl_id IS NULL OR item.product_tmpl_id = any(%s))
-                AND (item.product_id IS NULL OR item.product_id = any(%s))
-                AND (item.categ_id IS NULL OR item.categ_id = any(%s))
-                AND (item.commission_id = %s)
-                AND (item.active = TRUE)
-            ORDER BY
-                item.applied_on, item.based_on, categ.complete_name desc
-            """,
-            (
-                product.product_tmpl_id.ids,
-                product.ids,
-                categ_ids,
-                commission._origin.id,  # Added this
-            ),
+            self._commission_items_query(),
+            self._commission_items_query_params(commission, product),
         )
         item_ids = [x[0] for x in self.env.cr.fetchall()]
         return item_ids

--- a/sale_commission_product_criteria/models/sale_commission_line_mixin.py
+++ b/sale_commission_product_criteria/models/sale_commission_line_mixin.py
@@ -59,6 +59,8 @@ class SaleCommissionLineMixin(models.AbstractModel):
         }
 
     def _get_commission_items(self, commission, product):
+        if not commission:
+            return []
         self.env.cr.execute(
             self._commission_items_query(),
             self._commission_items_query_params(commission, product),

--- a/sale_commission_product_criteria/readme/CONTRIBUTORS.rst
+++ b/sale_commission_product_criteria/readme/CONTRIBUTORS.rst
@@ -1,3 +1,6 @@
 * `Ooops404 <https://www.ooops404.com>`__:
 
   * Ilyas <irazor147@gmail.com>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>

--- a/sale_commission_product_criteria/static/description/index.html
+++ b/sale_commission_product_criteria/static/description/index.html
@@ -428,6 +428,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Ilyas &lt;<a class="reference external" href="mailto:irazor147&#64;gmail.com">irazor147&#64;gmail.com</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.pytech.it">PyTech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;pytech.it">simone.rubino&#64;pytech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/sale_commission_product_criteria/tests/test_sale_commission_product_criteria.py
+++ b/sale_commission_product_criteria/tests/test_sale_commission_product_criteria.py
@@ -214,3 +214,20 @@ class TestSaleCommission(SavepointCase):
         with self.assertRaises(ValidationError):
             self.rules_commission_id.commission_type = "fixed"
             self.rules_commission_id.onchange_commission_type()
+
+    def test_get_items_without_commission(self):
+        """When there is no commission,
+        no items should be found by `_get_commission_items`."""
+        # Arrange
+        product = self.product_4
+        sale_order = self._create_sale_order(product, self.partner)
+        agent_line = sale_order.order_line.agent_ids
+
+        # Act
+        items_ids = agent_line._get_commission_items(
+            self.commission_model.browse(),
+            product,
+        )
+
+        # Assert
+        self.assertFalse(items_ids)

--- a/sale_commission_product_criteria_domain/models/sale_commission_line_mixin.py
+++ b/sale_commission_product_criteria_domain/models/sale_commission_line_mixin.py
@@ -7,59 +7,62 @@ class SaleCommissionLineMixin(models.AbstractModel):
     _inherit = "sale.commission.line.mixin"
 
     def _get_commission_items(self, commission, product):
-        # Method replaced
-        categ_ids = {}
-        categ = product.categ_id
-        while categ:
-            categ_ids[categ.id] = True
-            categ = categ.parent_id
-        categ_ids = list(categ_ids)
-
-        # Module specific mod:
-        if self.object_id._name == "sale.order.line":
-            partner = self.object_id.order_id.partner_id
-        elif self.object_id._name == "account.move.line":
-            partner = self.object_id.partner_id
+        res = []
+        if commission.commission_type != "product_restricted":
+            res = super()._get_commission_items(commission, product)
         else:
-            partner = False
-        if partner:
-            group_ids = (
-                partner.commission_item_agent_ids.filtered(
-                    lambda x: x.agent_id == self.agent_id
+            categ_ids = {}
+            categ = product.categ_id
+            while categ:
+                categ_ids[categ.id] = True
+                categ = categ.parent_id
+            categ_ids = list(categ_ids)
+
+            # Module specific mod:
+            if self.object_id._name == "sale.order.line":
+                partner = self.object_id.order_id.partner_id
+            elif self.object_id._name == "account.move.line":
+                partner = self.object_id.partner_id
+            else:
+                partner = False
+            if partner:
+                group_ids = (
+                    partner.commission_item_agent_ids.filtered(
+                        lambda x: x.agent_id == self.agent_id
+                    )
+                    .mapped("group_ids")
+                    .ids
                 )
-                .mapped("group_ids")
-                .ids
-            )
-        else:
-            group_ids = []
+            else:
+                group_ids = []
 
-        # Select all suitable items. Order by best match
-        # (priority is: all/cat/subcat/product/variant).
-        self.env.cr.execute(
-            """
-            SELECT
-                item.id
-            FROM
-                commission_item AS item
-            LEFT JOIN product_category AS categ ON item.categ_id = categ.id
-            LEFT JOIN commission_item_agent AS cia ON item.group_id = cia.id
-            WHERE
-                (item.product_tmpl_id IS NULL OR item.product_tmpl_id = any(%s))
-                AND (item.product_id IS NULL OR item.product_id = any(%s))
-                AND (item.categ_id IS NULL OR item.categ_id = any(%s))
-                AND (item.commission_id = %s)
-                AND (item.active = TRUE)
-                AND (cia.id IS NULL OR cia.id = any(%s))
-            ORDER BY
-                item.applied_on, item.based_on, categ.complete_name desc
-            """,
-            (
-                product.product_tmpl_id.ids,
-                product.ids,
-                categ_ids,
-                commission._origin.id,
-                group_ids,
-            ),
-        )
-        item_ids = [x[0] for x in self.env.cr.fetchall()]
-        return item_ids
+            # Select all suitable items. Order by best match
+            # (priority is: all/cat/subcat/product/variant).
+            self.env.cr.execute(
+                """
+                SELECT
+                    item.id
+                FROM
+                    commission_item AS item
+                LEFT JOIN product_category AS categ ON item.categ_id = categ.id
+                LEFT JOIN commission_item_agent AS cia ON item.group_id = cia.id
+                WHERE
+                    (item.product_tmpl_id IS NULL OR item.product_tmpl_id = any(%s))
+                    AND (item.product_id IS NULL OR item.product_id = any(%s))
+                    AND (item.categ_id IS NULL OR item.categ_id = any(%s))
+                    AND (item.commission_id = %s)
+                    AND (item.active = TRUE)
+                    AND (cia.id IS NULL OR cia.id = any(%s))
+                ORDER BY
+                    item.applied_on, item.based_on, categ.complete_name desc
+                """,
+                (
+                    product.product_tmpl_id.ids,
+                    product.ids,
+                    categ_ids,
+                    commission._origin.id,
+                    group_ids,
+                ),
+            )
+            res = [x[0] for x in self.env.cr.fetchall()]
+        return res


### PR DESCRIPTION
Backporting 2 small PRs from `16.0`: https://github.com/OCA/commission/pull/615 and https://github.com/OCA/commission/pull/619.
@Tisho99, @ValentinVinagre and @manuelregidor thanks for your work on those PRs!
Maybe you want to have a look?

---
I have also a dded a fix for method `_get_commission_items`: unfortunately I don't know ho to reproduce it from the UI, but calling the method with an empty `commission` raises:
```
ERROR: operator does not exist: integer = boolean
LINE 9:             AND (item.commission_id = false)
                                            ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts
```
See the added test for more details.