### PR TITLE
[19.0][IMP] commission*: Renamed agent_ids to partner_agent_ids

### DIFF
--- a/account_commission_oca/README.rst
+++ b/account_commission_oca/README.rst
@@ -53,10 +53,10 @@ For selecting invoice status in commissions:
 1. Edit or create a new record to select the invoice status for settling
    the commissions.
 
-   - **Invoice Based**: Commissions are settled when the invoice is
-     issued.
-   - **Payment Based**: Commissions are settled when the invoice is
-     paid.
+   -  **Invoice Based**: Commissions are settled when the invoice is
+      issued.
+   -  **Payment Based**: Commissions are settled when the invoice is
+      paid.
 
 Usage
 =====
@@ -85,12 +85,13 @@ For invoicing the settlements (only for external agents):
 1. Go to *Invoicing > Commissions > Create Commission Invoices*.
 2. On the window that appears, you can select following data:
 
-   - Product. It should be a service product for being coherent.
-   - Journal: To be selected between existing purchase journals.
-   - Date: If you want to choose a specific invoice date. You can leave
-     it blank if you prefer.
-   - Settlements: For selecting specific settlements to invoice. You can
-     leave it blank as well for invoicing all the pending settlements.
+   -  Product. It should be a service product for being coherent.
+   -  Journal: To be selected between existing purchase journals.
+   -  Date: If you want to choose a specific invoice date. You can leave
+      it blank if you prefer.
+   -  Settlements: For selecting specific settlements to invoice. You
+      can leave it blank as well for invoicing all the pending
+      settlements.
 
 If you want to invoice a/some specific settlement/s:
 
@@ -121,35 +122,35 @@ Authors
 Contributors
 ------------
 
-- Pexego.
-- Davide Corio <davide.corio@domsense.com>
-- Joao Alfredo Gama Batista <joao.gama@savoirfairelinux.com>
-- Sandy Carter <sandy.carter@savoirfairelinux.com>
-- Giorgio Borelli <giorgio.borelli@abstract.it>
-- Daniel Campos <danielcampos@avanzosc.es>
-- Oihane Crucelaegui <oihanecruce@gmail.com>
-- Nicola Malcontenti <nicola.malcontenti@agilebg.com>
-- Aitor Bouzas <aitor.bouzas@adaptivecity.com>
-- Alexei Rivera <arivera@archeti.com>
-- Mina Samir <minaw349@outlook.com>
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  Pexego.
+-  Davide Corio <davide.corio@domsense.com>
+-  Joao Alfredo Gama Batista <joao.gama@savoirfairelinux.com>
+-  Sandy Carter <sandy.carter@savoirfairelinux.com>
+-  Giorgio Borelli <giorgio.borelli@abstract.it>
+-  Daniel Campos <danielcampos@avanzosc.es>
+-  Oihane Crucelaegui <oihanecruce@gmail.com>
+-  Nicola Malcontenti <nicola.malcontenti@agilebg.com>
+-  Aitor Bouzas <aitor.bouzas@adaptivecity.com>
+-  Alexei Rivera <arivera@archeti.com>
+-  Mina Samir <minaw349@outlook.com>
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Pedro M. Baeza
-  - Manuel Calero
+   -  Pedro M. Baeza
+   -  Manuel Calero
 
-- `Quartile <https://www.quartile.co>`__:
+-  `Quartile <https://www.quartile.co>`__:
 
-  - Aung Ko Ko Lin
-  - Yoshi Tashiro
+   -  Aung Ko Ko Lin
+   -  Yoshi Tashiro
 
-- `Studio73 <https://www.studio73.es>`__:
+-  `Studio73 <https://www.studio73.es>`__:
 
-  - Ethan Hildick
-  - Pablo Cortés
+   -  Ethan Hildick
+   -  Pablo Cortés
 
-- `Sygel <https://www.sygel.es>`__:
+-  `Sygel <https://www.sygel.es>`__:
 
-  - Alberto Martínez
+   -  Alberto Martínez
 
 Maintainers
 -----------

--- a/account_commission_oca/__manifest__.py
+++ b/account_commission_oca/__manifest__.py
@@ -3,7 +3,7 @@
 # Copyright 2014-2022 Tecnativa - Pedro M. Baeza
 {
     "name": "Account commissions OCA",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "category": "Sales Management",
     "license": "AGPL-3",

--- a/account_commission_oca/static/description/index.html
+++ b/account_commission_oca/static/description/index.html
@@ -437,8 +437,9 @@ partner on the invoice having already inserted lines.</li>
 <li>Journal: To be selected between existing purchase journals.</li>
 <li>Date: If you want to choose a specific invoice date. You can leave
 it blank if you prefer.</li>
-<li>Settlements: For selecting specific settlements to invoice. You can
-leave it blank as well for invoicing all the pending settlements.</li>
+<li>Settlements: For selecting specific settlements to invoice. You
+can leave it blank as well for invoicing all the pending
+settlements.</li>
 </ul>
 </li>
 </ol>

--- a/account_commission_oca/tests/test_account_commission.py
+++ b/account_commission_oca/tests/test_account_commission.py
@@ -231,7 +231,7 @@ class TestAccountCommission(TestCommissionBase):
 
     def test_supplier_invoice(self):
         """No agents should be populated on supplier invoices."""
-        self.partner.agent_ids = self.agent_semi
+        self.partner.commission_agent_ids = self.agent_semi
         invoice = self.env["account.move"].create(
             [
                 {
@@ -254,7 +254,7 @@ class TestAccountCommission(TestCommissionBase):
 
     def test_commission_propagation(self):
         """Test propagation of agents from partner to invoice."""
-        self.partner.agent_ids = [(4, self.agent_monthly.id)]
+        self.partner.commission_agent_ids = [(4, self.agent_monthly.id)]
         invoice = self.env["account.move"].create(
             [
                 {

--- a/commission_oca/README.rst
+++ b/commission_oca/README.rst
@@ -35,9 +35,9 @@ Commissions OCA
 This module provides the base functions for commission operations to
 enable the following:
 
-- Define agents with their commissions
-- Assign agents to partners
-- Create settlements to summarize commissions for certain periods
+-  Define agents with their commissions
+-  Assign agents to partners
+-  Create settlements to summarize commissions for certain periods
 
 You can define which base amount is going to be taken into account: net
 amount (based on margin) or gross amount (line subtotal amount).
@@ -57,19 +57,19 @@ For adding commissions:
 3. Select a name for distinguishing that type.
 4. Select the percentage type of the commission:
 
-   - **Fixed percentage**: all commissions are computed with a fixed
-     percentage. You can fill the percentage in the field "Fixed
-     percentage".
-   - **By sections**: percentage varies depending amount intervals. You
-     can fill intervals and percentages in the section "Rate
-     definition".
+   -  **Fixed percentage**: all commissions are computed with a fixed
+      percentage. You can fill the percentage in the field "Fixed
+      percentage".
+   -  **By sections**: percentage varies depending amount intervals. You
+      can fill intervals and percentages in the section "Rate
+      definition".
 
 5. Select the base amount for computing the percentage:
 
-   - **Sale/Invoice Amount**: percentage is computed from the amount put
-     on sales order/invoice.
-   - **Margin (Amount - Cost)**: percentage is computed from the profit
-     only, taken the cost from the product.
+   -  **Sale/Invoice Amount**: percentage is computed from the amount
+      put on sales order/invoice.
+   -  **Margin (Amount - Cost)**: percentage is computed from the profit
+      only, taken the cost from the product.
 
 For adding new agents:
 
@@ -84,12 +84,12 @@ For adding new agents:
 4. There's a new page called "Agent information". In it, you can set
    following data:
 
-   - The agent type, being in this base module "External agent" the only
-     existing configuration. It can be extended with hr_commission
-     module for setting an "Employee" agent type.
-   - The associated commission type.
-   - The settlement period, where you can select "Bi-weekly", "Monthly",
-     "Quaterly", "Semi-annual" or "Annual".
+   -  The agent type, being in this base module "External agent" the
+      only existing configuration. It can be extended with hr_commission
+      module for setting an "Employee" agent type.
+   -  The associated commission type.
+   -  The settlement period, where you can select "Bi-weekly",
+      "Monthly", "Quaterly", "Semi-annual" or "Annual".
 
    You will also be able to see the settlements that have been made to
    this agent from this page.
@@ -121,9 +121,9 @@ For settling the commissions to agents:
 Known issues / Roadmap
 ======================
 
-- Make it totally multi-company aware.
-- Set agent popup window with a kanban view with richer information and
-  mobile friendly.
+-  Make it totally multi-company aware.
+-  Set agent popup window with a kanban view with richer information and
+   mobile friendly.
 
 Bug Tracker
 ===========
@@ -146,32 +146,32 @@ Authors
 Contributors
 ------------
 
-- Pexego.
-- Davide Corio <davide.corio@domsense.com>
-- Joao Alfredo Gama Batista <joao.gama@savoirfairelinux.com>
-- Sandy Carter <sandy.carter@savoirfairelinux.com>
-- Giorgio Borelli <giorgio.borelli@abstract.it>
-- Daniel Campos <danielcampos@avanzosc.es>
-- Oihane Crucelaegui <oihanecruce@gmail.com>
-- Nicola Malcontenti <nicola.malcontenti@agilebg.com>
-- Aitor Bouzas <aitor.bouzas@adaptivecity.com>
-- Alexei Rivera <arivera@archeti.com>
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  Pexego.
+-  Davide Corio <davide.corio@domsense.com>
+-  Joao Alfredo Gama Batista <joao.gama@savoirfairelinux.com>
+-  Sandy Carter <sandy.carter@savoirfairelinux.com>
+-  Giorgio Borelli <giorgio.borelli@abstract.it>
+-  Daniel Campos <danielcampos@avanzosc.es>
+-  Oihane Crucelaegui <oihanecruce@gmail.com>
+-  Nicola Malcontenti <nicola.malcontenti@agilebg.com>
+-  Aitor Bouzas <aitor.bouzas@adaptivecity.com>
+-  Alexei Rivera <arivera@archeti.com>
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Pedro M. Baeza
-  - Manuel Calero
+   -  Pedro M. Baeza
+   -  Manuel Calero
 
-- `Quartile <https://www.quartile.co>`__:
+-  `Quartile <https://www.quartile.co>`__:
 
-  - Aung Ko Ko Lin
-  - Yoshi Tashiro
+   -  Aung Ko Ko Lin
+   -  Yoshi Tashiro
 
-- `Studio73 <https://www.studio73.es>`__:
+-  `Studio73 <https://www.studio73.es>`__:
 
-  - Ethan Hildick
-  - Pablo Cortés
+   -  Ethan Hildick
+   -  Pablo Cortés
 
-- Moaad Bourhim
+-  Moaad Bourhim
 
 Maintainers
 -----------

--- a/commission_oca/__manifest__.py
+++ b/commission_oca/__manifest__.py
@@ -3,7 +3,7 @@
 # Copyright 2014-2022 Tecnativa - Pedro M. Baeza
 {
     "name": "Commissions OCA",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "category": "Invoicing",
     "license": "AGPL-3",

--- a/commission_oca/migrations/19.0.2.0.0/pre-migrate.py
+++ b/commission_oca/migrations/19.0.2.0.0/pre-migrate.py
@@ -1,0 +1,16 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_fields(
+        env,
+        [
+            (
+                "res.partner",
+                env["res.partner"]._table,
+                "agent_ids",
+                "commission_agent_ids",
+            ),
+        ],
+    )

--- a/commission_oca/models/commission_mixin.py
+++ b/commission_oca/models/commission_mixin.py
@@ -37,7 +37,7 @@ class CommissionMixin(models.AbstractModel):
 
     def _prepare_agents_vals_partner(self, partner, settlement_type=None):
         """Utility method for getting agents creation dictionary of a partner."""
-        agents = partner.agent_ids
+        agents = partner.commission_agent_ids
         if settlement_type:
             agents = agents.filtered(
                 lambda x: not x.commission_id.settlement_type

--- a/commission_oca/models/res_partner.py
+++ b/commission_oca/models/res_partner.py
@@ -10,7 +10,7 @@ class ResPartner(models.Model):
 
     _inherit = "res.partner"
 
-    agent_ids = fields.Many2many(
+    commission_agent_ids = fields.Many2many(
         comodel_name="res.partner",
         relation="partner_agent_rel",
         column1="partner_id",
@@ -57,5 +57,5 @@ class ResPartner(models.Model):
     def _commercial_fields(self):
         """Add agents to commercial fields that are synced from parent to childs."""
         res = super()._commercial_fields()
-        res.append("agent_ids")
+        res.append("commission_agent_ids")
         return res

--- a/commission_oca/static/description/index.html
+++ b/commission_oca/static/description/index.html
@@ -416,8 +416,8 @@ definition”.</li>
 </ul>
 </li>
 <li>Select the base amount for computing the percentage:<ul>
-<li><strong>Sale/Invoice Amount</strong>: percentage is computed from the amount put
-on sales order/invoice.</li>
+<li><strong>Sale/Invoice Amount</strong>: percentage is computed from the amount
+put on sales order/invoice.</li>
 <li><strong>Margin (Amount - Cost)</strong>: percentage is computed from the profit
 only, taken the cost from the product.</li>
 </ul>
@@ -436,12 +436,12 @@ if you have accessed from first menu option.</p>
 <li><p class="first">There’s a new page called “Agent information”. In it, you can set
 following data:</p>
 <ul class="simple">
-<li>The agent type, being in this base module “External agent” the only
-existing configuration. It can be extended with hr_commission
+<li>The agent type, being in this base module “External agent” the
+only existing configuration. It can be extended with hr_commission
 module for setting an “Employee” agent type.</li>
 <li>The associated commission type.</li>
-<li>The settlement period, where you can select “Bi-weekly”, “Monthly”,
-“Quaterly”, “Semi-annual” or “Annual”.</li>
+<li>The settlement period, where you can select “Bi-weekly”,
+“Monthly”, “Quaterly”, “Semi-annual” or “Annual”.</li>
 </ul>
 <p>You will also be able to see the settlements that have been made to
 this agent from this page.</p>

--- a/commission_oca/tests/test_commission.py
+++ b/commission_oca/tests/test_commission.py
@@ -170,17 +170,24 @@ class TestCommission(TestCommissionBase):
         partner = self.env["res.partner"].create(
             {
                 "name": "Test partner",
-                "agent_ids": [(4, self.agent_monthly.id), (4, self.agent_quaterly.id)],
+                "commission_agent_ids": [
+                    (4, self.agent_monthly.id),
+                    (4, self.agent_quaterly.id),
+                ],
             }
         )
         # Create
         child = self.env["res.partner"].create(
             {"name": "Test child", "parent_id": partner.id}
         )
-        self.assertEqual(set(child.agent_ids.ids), set(partner.agent_ids.ids))
+        self.assertEqual(
+            set(child.commission_agent_ids.ids), set(partner.commission_agent_ids.ids)
+        )
         # Write
-        partner.agent_ids = [(4, self.agent_annual.id)]
-        self.assertEqual(set(child.agent_ids.ids), set(partner.agent_ids.ids))
+        partner.commission_agent_ids = [(4, self.agent_annual.id)]
+        self.assertEqual(
+            set(child.commission_agent_ids.ids), set(partner.commission_agent_ids.ids)
+        )
 
     def test_auto_subscribe_agent(self):
         settlement = self._create_settlement(

--- a/commission_oca/views/res_partner_views.xml
+++ b/commission_oca/views/res_partner_views.xml
@@ -14,7 +14,7 @@
                 position="after"
             >
                 <field
-                    name="agent_ids"
+                    name="commission_agent_ids"
                     widget="many2many_tags"
                     context="{'default_agent': True}"
                 />

--- a/sale_commission_oca/README.rst
+++ b/sale_commission_oca/README.rst
@@ -88,30 +88,30 @@ Authors
 Contributors
 ------------
 
-- Pexego.
-- Davide Corio <davide.corio@domsense.com>
-- Joao Alfredo Gama Batista <joao.gama@savoirfairelinux.com>
-- Sandy Carter <sandy.carter@savoirfairelinux.com>
-- Giorgio Borelli <giorgio.borelli@abstract.it>
-- Daniel Campos <danielcampos@avanzosc.es>
-- Oihane Crucelaegui <oihanecruce@gmail.com>
-- Nicola Malcontenti <nicola.malcontenti@agilebg.com>
-- Aitor Bouzas <aitor.bouzas@adaptivecity.com>
-- Mina Samir <<minaw368@gmail.com>
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  Pexego.
+-  Davide Corio <davide.corio@domsense.com>
+-  Joao Alfredo Gama Batista <joao.gama@savoirfairelinux.com>
+-  Sandy Carter <sandy.carter@savoirfairelinux.com>
+-  Giorgio Borelli <giorgio.borelli@abstract.it>
+-  Daniel Campos <danielcampos@avanzosc.es>
+-  Oihane Crucelaegui <oihanecruce@gmail.com>
+-  Nicola Malcontenti <nicola.malcontenti@agilebg.com>
+-  Aitor Bouzas <aitor.bouzas@adaptivecity.com>
+-  Mina Samir <<minaw368@gmail.com>
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Pedro M. Baeza
-  - Manuel Calero
+   -  Pedro M. Baeza
+   -  Manuel Calero
 
-- `Quartile <https://www.quartile.co>`__:
+-  `Quartile <https://www.quartile.co>`__:
 
-  - Aung Ko Ko Lin
-  - Yoshi Tashiro
+   -  Aung Ko Ko Lin
+   -  Yoshi Tashiro
 
-- `Studio73 <https://www.studio73.es>`__:
+-  `Studio73 <https://www.studio73.es>`__:
 
-  - Ethan Hildick
-  - Pablo Cortés
+   -  Ethan Hildick
+   -  Pablo Cortés
 
 Maintainers
 -----------

--- a/sale_commission_oca/__manifest__.py
+++ b/sale_commission_oca/__manifest__.py
@@ -3,7 +3,7 @@
 # Copyright 2014-2022 Tecnativa - Pedro M. Baeza
 {
     "name": "Sales commissions OCA",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "category": "Sales Management",
     "license": "AGPL-3",

--- a/sale_commission_oca/tests/test_sale_commission.py
+++ b/sale_commission_oca/tests/test_sale_commission.py
@@ -105,7 +105,7 @@ class TestSaleCommission(TestAccountCommission):
         self.assertEqual(action["res_id"], sale_order.order_line.id)
 
     def test_sale_commission_propagation(self):
-        self.partner.agent_ids = [(4, self.agent_monthly.id)]
+        self.partner.commission_agent_ids = [(4, self.agent_monthly.id)]
         sale_order_form = Form(self.env["sale.order"])
         sale_order_form.partner_id = self.partner
         with sale_order_form.order_line.new() as line_form:


### PR DESCRIPTION
Rename the agent_ids field to partner_agent_id because in Odoo version 19, the AI ​​module already adds the same field to res.partner, but this one refers to ai.agent.
