### PR TITLE
[14.0][FIX] sale_commission_product_criteria: address same label warning

### DIFF
--- a/sale_commission_product_criteria/models/commission.py
+++ b/sale_commission_product_criteria/models/commission.py
@@ -71,7 +71,6 @@ class CommissionItem(models.Model):
     active = fields.Boolean(default=True)
     commission_id = fields.Many2one(
         "sale.commission",
-        string="Commission Type",
         domain=[("commission_type", "=", "product")],
         required=True,
     )


### PR DESCRIPTION
Fixes the following warning

```
2026-03-31 12:14:35,919 1 WARNING devel odoo.addons.base.models.ir_model: Two fields (commission_type, commission_id) of commission.item() have the same label: Commission Type. 
```