### PR TITLE
[IMP] sale_commission: Set report default views

### DIFF
--- a/sale_commission/report/sale_commission_analysis_report_view.xml
+++ b/sale_commission/report/sale_commission_analysis_report_view.xml
@@ -103,7 +103,7 @@
     <record id="action_sale_commission_analysis_report" model="ir.actions.act_window">
         <field name="name">Commission Analysis</field>
         <field name="res_model">sale.commission.analysis.report</field>
-        <field name="binding_view_types">form,pivot,graph</field>
+        <field name="view_mode">form,pivot,graph</field>
         <field name="search_view_id" ref="view_sale_commission_analysis_search" />
         <field name="view_id" ref="view_sale_commission_analysis_graph" />
         <field


### PR DESCRIPTION
Open the "Commission Analysis" report.

**Before this change**: 
<img width="2560" height="1247" alt="image" src="https://github.com/user-attachments/assets/ffc9e654-df58-4ae3-ac61-4974eb55dfac" />

**After this change**:
<img width="2560" height="1247" alt="image" src="https://github.com/user-attachments/assets/0355a0e5-1c1b-49e5-a759-7f0b9a6f2c56" />

I don't think this has to be forward ported because I haven't found this report in other versions: maybe it has been removed, or maybe has been added in `14.0` after migration :man_shrugging: